### PR TITLE
Don't strip rackId inside addRequestId method

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -68,7 +68,11 @@ public class BaragonRequest {
   }
 
   private UpstreamInfo addRequestId(UpstreamInfo upstream, String requestId) {
-    return new UpstreamInfo(upstream.getUpstream(), Optional.of(requestId), Optional.<String>absent());
+    if (!upstream.getRequestId().isPresent()) {
+      return new UpstreamInfo(upstream.getUpstream(), Optional.of(requestId), upstream.getRackId());
+    } else {
+      return upstream;
+    }
   }
 
   @Override


### PR DESCRIPTION
There is a bug in `addRequestId` causing it to always strip the rackId
