### PR TITLE
Keep track of all known agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ target
 .project
 .classpath
 .settings
+
+tmp/*

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -126,7 +126,8 @@ public class BaragonAgentServiceModule extends AbstractModule {
 
     final String appRoot = ((SimpleServerFactory)config.getServerFactory()).getApplicationContextPath();
     final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
-    return new BaragonAgentMetadata(baseAgentUri, domain);
+    final String agentId = String.format("%s:%s", hostname, httpPort);
+    return new BaragonAgentMetadata(baseAgentUri, agentId, domain);
   }
 
   @Provides

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -1,5 +1,6 @@
 package com.hubspot.baragon.agent;
 
+import com.hubspot.baragon.data.BaragonKnownAgentsDatastore;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.SimpleServerFactory;
 
@@ -40,6 +41,7 @@ public class BaragonAgentServiceModule extends AbstractModule {
   public static final String AGENT_TEMPLATES = "baragon.agent.templates";
   public static final String AGENT_MOST_RECENT_REQUEST_ID = "baragon.agent.mostRecentRequestId";
   public static final String AGENT_LOCK_TIMEOUT_MS = "baragon.agent.lock.timeoutMs";
+  public static final String BARAGON_AGENT_METADATA = "baragon.agent.metadata";
 
   @Override
   protected void configure() {
@@ -116,16 +118,24 @@ public class BaragonAgentServiceModule extends AbstractModule {
 
   @Provides
   @Singleton
+  @Named(BARAGON_AGENT_METADATA)
+  public BaragonAgentMetadata providesAgentMetadata(BaragonAgentConfiguration config,
+                                                    @Named(BARAGON_AGENT_HTTP_PORT) int httpPort,
+                                                    @Named(BARAGON_AGENT_HOSTNAME) String hostname,
+                                                    @Named(BARAGON_AGENT_DOMAIN) Optional<String> domain) {
+
+    final String appRoot = ((SimpleServerFactory)config.getServerFactory()).getApplicationContextPath();
+    final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
+    return new BaragonAgentMetadata(baseAgentUri, domain);
+  }
+
+  @Provides
+  @Singleton
   @Named(AGENT_LEADER_LATCH)
   public LeaderLatch providesAgentLeaderLatch(BaragonLoadBalancerDatastore loadBalancerDatastore,
                                               BaragonAgentConfiguration config,
-                                              @Named(BARAGON_AGENT_HTTP_PORT) int httpPort,
-                                              @Named(BARAGON_AGENT_HOSTNAME) String hostname,
-                                              @Named(BARAGON_AGENT_DOMAIN) Optional<String> domain) {
-    final String appRoot = ((SimpleServerFactory)config.getServerFactory()).getApplicationContextPath();
-    final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
-
-    return loadBalancerDatastore.createLeaderLatch(config.getLoadBalancerConfiguration().getName(), new BaragonAgentMetadata(baseAgentUri, domain));
+                                              @Named(BARAGON_AGENT_METADATA) BaragonAgentMetadata baragonAgentMetadata) {
+    return loadBalancerDatastore.createLeaderLatch(config.getLoadBalancerConfiguration().getName(), baragonAgentMetadata);
   }
 
   @Provides

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -31,8 +31,6 @@ public class BootstrapManaged implements Managed {
   private final LeaderLatch leaderLatch;
   private final BaragonKnownAgentsDatastore knownAgentsDatastore;
   private final BaragonAgentMetadata baragonAgentMetadata;
-  private final int httpPort;
-  private final String localHostname;
   
   @Inject
   public BootstrapManaged(BaragonStateDatastore stateDatastore,
@@ -40,17 +38,13 @@ public class BootstrapManaged implements Managed {
                           LoadBalancerConfiguration loadBalancerConfiguration,
                           FilesystemConfigHelper configHelper,
                           @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch,
-                          @Named(BaragonAgentServiceModule.BARAGON_AGENT_METADATA)BaragonAgentMetadata baragonAgentMetadata,
-                          @Named(BaragonAgentServiceModule.BARAGON_AGENT_HTTP_PORT)int httpPort,
-                          @Named(BaragonAgentServiceModule.BARAGON_AGENT_HOSTNAME)String localHostname) {
+                          @Named(BaragonAgentServiceModule.BARAGON_AGENT_METADATA) BaragonAgentMetadata baragonAgentMetadata) {
     this.loadBalancerConfiguration = loadBalancerConfiguration;
     this.configHelper = configHelper;
     this.stateDatastore = stateDatastore;
     this.leaderLatch = leaderLatch;
     this.knownAgentsDatastore = knownAgentsDatastore;
     this.baragonAgentMetadata = baragonAgentMetadata;
-    this.httpPort = httpPort;
-    this.localHostname = localHostname;
   }
 
   private void applyCurrentConfigs() {
@@ -88,8 +82,7 @@ public class BootstrapManaged implements Managed {
     leaderLatch.start();
 
     LOG.info("Adding to known-agents...");
-    String agentKey = localHostname + ":" + Integer.toString(httpPort);
-    knownAgentsDatastore.addKnownAgent(loadBalancerConfiguration.getName(), baragonAgentMetadata, agentKey);
+    knownAgentsDatastore.addKnownAgent(loadBalancerConfiguration.getName(), baragonAgentMetadata);
   }
 
   @Override

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -6,6 +6,8 @@ import io.dropwizard.lifecycle.Managed;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
@@ -82,8 +84,11 @@ public class BootstrapManaged implements Managed {
     leaderLatch.start();
 
     LOG.info("Adding to known-agents...");
-    String localhostname = java.net.InetAddress.getLocalHost().getHostName();
-    knownAgentsDatastore.addKnownAgent(loadBalancerConfiguration.getName(), baragonAgentMetadata, localhostname);
+    Pattern pattern = Pattern.compile("http[s]?:\\/\\/([^:\\/]+:\\d{1,5})\\/");
+    Matcher matcher = pattern.matcher(baragonAgentMetadata.getBaseAgentUri());
+    matcher.find();
+    String agentKey = matcher.group(1);
+    knownAgentsDatastore.addKnownAgent(loadBalancerConfiguration.getName(), baragonAgentMetadata, agentKey);
   }
 
   @Override

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -1,5 +1,7 @@
 package com.hubspot.baragon.agent.managed;
 
+import com.hubspot.baragon.data.BaragonKnownAgentsDatastore;
+import com.hubspot.baragon.models.BaragonAgentMetadata;
 import io.dropwizard.lifecycle.Managed;
 
 import java.util.Collection;
@@ -27,16 +29,22 @@ public class BootstrapManaged implements Managed {
   private final FilesystemConfigHelper configHelper;
   private final BaragonStateDatastore stateDatastore;
   private final LeaderLatch leaderLatch;
+  private final BaragonKnownAgentsDatastore knownAgentsDatastore;
+  private final BaragonAgentMetadata baragonAgentMetadata;
   
   @Inject
   public BootstrapManaged(BaragonStateDatastore stateDatastore,
+                          BaragonKnownAgentsDatastore knownAgentsDatastore,
                           LoadBalancerConfiguration loadBalancerConfiguration,
                           FilesystemConfigHelper configHelper,
-                          @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch) {
+                          @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch,
+                          @Named(BaragonAgentServiceModule.BARAGON_AGENT_METADATA)BaragonAgentMetadata baragonAgentMetadata) {
     this.loadBalancerConfiguration = loadBalancerConfiguration;
     this.configHelper = configHelper;
     this.stateDatastore = stateDatastore;
     this.leaderLatch = leaderLatch;
+    this.knownAgentsDatastore = knownAgentsDatastore;
+    this.baragonAgentMetadata = baragonAgentMetadata;
   }
 
   private void applyCurrentConfigs() {
@@ -72,6 +80,10 @@ public class BootstrapManaged implements Managed {
 
     LOG.info("Starting leader latch...");
     leaderLatch.start();
+
+    LOG.info("Adding to known-agents...");
+    String localhostname = java.net.InetAddress.getLocalHost().getHostName();
+    knownAgentsDatastore.addKnownAgent(loadBalancerConfiguration.getName(), baragonAgentMetadata, localhostname);
   }
 
   @Override

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -5,22 +5,31 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class BaragonAgentMetadata {
   private final String baseAgentUri;
   private final Optional<String> domain;
+  private final String agentId;
 
   @JsonCreator
   public static BaragonAgentMetadata fromString(String value) {
-    return new BaragonAgentMetadata(value, Optional.<String>absent());
+    Pattern pattern = Pattern.compile("http[s]?:\\/\\/([^:\\/]+:\\d{1,5})\\/");
+    Matcher matcher = pattern.matcher(value);
+    matcher.find();
+    String agentId = matcher.group(1);
+    return new BaragonAgentMetadata(value, agentId, Optional.<String>absent());
   }
 
   @JsonCreator
   public BaragonAgentMetadata(@JsonProperty("baseAgentUri") String baseAgentUri,
+                              @JsonProperty("agentId") String agentId,
                               @JsonProperty("domain") Optional<String> domain) {
     this.baseAgentUri = baseAgentUri;
     this.domain = domain;
+    this.agentId = agentId;
   }
 
   public String getBaseAgentUri() {
@@ -31,10 +40,15 @@ public class BaragonAgentMetadata {
     return domain;
   }
 
+  public String getAgentId() {
+    return agentId;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-        .add("baseAgentUri", baseAgentUri)
+            .add("baseAgentUri", baseAgentUri)
+        .add("agentId", agentId)
         .add("domain", domain)
         .toString();
   }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
@@ -76,7 +76,7 @@ public class BaragonKnownAgentsDatastore extends AbstractDataStore {
     writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId), agentMetadata);
   }
 
-  public void clearKnownAgent(String clusterName, String agentId) {
+  public void removeKnownAgent(String clusterName, String agentId) {
     deleteNode(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId));
   }
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
@@ -47,7 +47,7 @@ public class BaragonKnownAgentsDatastore extends AbstractDataStore {
       try {
         final String value = new String(curatorFramework.getData().forPath(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, node)), Charsets.UTF_8);
         if (value.startsWith("http://")) {
-          metadata.add(new BaragonAgentMetadata(value, Optional.<String>absent()));
+          metadata.add(BaragonAgentMetadata.fromString(value));
         } else {
           metadata.add(objectMapper.readValue(value, BaragonAgentMetadata.class));
         }
@@ -72,8 +72,8 @@ public class BaragonKnownAgentsDatastore extends AbstractDataStore {
     return metadata;
   }
 
-  public void addKnownAgent(String clusterName, BaragonAgentMetadata agentMetadata, String agentId) {
-    writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId), agentMetadata);
+  public void addKnownAgent(String clusterName, BaragonAgentMetadata agentMetadata) {
+    writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentMetadata.getAgentId()), agentMetadata);
   }
 
   public void removeKnownAgent(String clusterName, String agentId) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
@@ -1,0 +1,87 @@
+package com.hubspot.baragon.data;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.baragon.models.BaragonAgentMetadata;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+@Singleton
+public class BaragonKnownAgentsDatastore extends AbstractDataStore {
+  private static final Logger LOG = LoggerFactory.getLogger(BaragonKnownAgentsDatastore.class);
+
+  public static final String KNOWN_AGENTS_GROUP_HOSTS_FORMAT = "/load-balancer/%s/known-agents";
+  public static final String KNOWN_AGENTS_GROUP_HOST_FORMAT = KNOWN_AGENTS_GROUP_HOSTS_FORMAT + "/%s";
+
+  @Inject
+  public BaragonKnownAgentsDatastore(CuratorFramework curatorFramework, ObjectMapper objectMapper) {
+    super(curatorFramework, objectMapper);
+  }
+
+  public Collection<BaragonAgentMetadata> getKnownAgentsMetadata(String clusterName) {
+    final Collection<String> nodes = getChildren(String.format(KNOWN_AGENTS_GROUP_HOSTS_FORMAT, clusterName));
+
+    if (nodes.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    final Collection<BaragonAgentMetadata> metadata = Lists.newArrayListWithCapacity(nodes.size());
+
+    for (String node : nodes) {
+      try {
+        final String value = new String(curatorFramework.getData().forPath(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, node)), Charsets.UTF_8);
+        if (value.startsWith("http://")) {
+          metadata.add(new BaragonAgentMetadata(value, Optional.<String>absent()));
+        } else {
+          metadata.add(objectMapper.readValue(value, BaragonAgentMetadata.class));
+        }
+      } catch (KeeperException.NoNodeException nne) {
+      } catch (JsonParseException | JsonMappingException je) {
+        LOG.warn(String.format("Exception deserializing %s", String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, node)), je);
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    return metadata;
+  }
+
+  public Collection<BaragonAgentMetadata> getKnownAgentsMetadata(Collection<String> clusterNames) {
+    final Set<BaragonAgentMetadata> metadata = Sets.newHashSet();
+
+    for (String clusterName : clusterNames) {
+      metadata.addAll(getKnownAgentsMetadata(clusterName));
+    }
+
+    return metadata;
+  }
+
+  public void addKnownAgent(String clusterName, BaragonAgentMetadata agentMetadata, String agentId) {
+    try {
+    writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId), objectMapper.writeValueAsString(agentMetadata));
+    } catch (JsonProcessingException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  public void clearKnownAgent(String clusterName, String node) {
+    deleteNode(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, node));
+  }
+
+}

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonKnownAgentsDatastore.java
@@ -73,15 +73,11 @@ public class BaragonKnownAgentsDatastore extends AbstractDataStore {
   }
 
   public void addKnownAgent(String clusterName, BaragonAgentMetadata agentMetadata, String agentId) {
-    try {
-    writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId), objectMapper.writeValueAsString(agentMetadata));
-    } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
-    }
+    writeToZk(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId), agentMetadata);
   }
 
-  public void clearKnownAgent(String clusterName, String node) {
-    deleteNode(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, node));
+  public void clearKnownAgent(String clusterName, String agentId) {
+    deleteNode(String.format(KNOWN_AGENTS_GROUP_HOST_FORMAT, clusterName, agentId));
   }
 
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -64,7 +64,7 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
       try {
         final String value = new String(curatorFramework.getData().forPath(String.format(LOAD_BALANCER_GROUP_HOST_FORMAT, clusterName, node)), Charsets.UTF_8);
         if (value.startsWith("http://")) {
-          metadata.add(new BaragonAgentMetadata(value, Optional.<String>absent()));
+          metadata.add(BaragonAgentMetadata.fromString(value));
         } else {
           metadata.add(objectMapper.readValue(value, BaragonAgentMetadata.class));
         }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
@@ -69,9 +69,9 @@ public class LoadBalancerResource {
   }
 
   @DELETE
-  @Path("/{clusterName}/known-agents")
-  public void deleteKnownAgent(@PathParam("clusterName") String clusterName, @QueryParam("agentId") String agentId) {
-    knownAgentsDatastore.clearKnownAgent(clusterName, agentId);
+  @Path("/{clusterName}/known-agents/{agentId}")
+  public void deleteKnownAgent(@PathParam("clusterName") String clusterName, @PathParam("agentId") String agentId) {
+    knownAgentsDatastore.removeKnownAgent(clusterName, agentId);
   }
 
   @GET

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.MediaType;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.hubspot.baragon.data.BaragonKnownAgentsDatastore;
 import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
@@ -24,12 +25,15 @@ import com.hubspot.baragon.models.BaragonService;
 @Consumes(MediaType.APPLICATION_JSON)
 public class LoadBalancerResource {
   private final BaragonLoadBalancerDatastore loadBalancerDatastore;
+  private final BaragonKnownAgentsDatastore knownAgentsDatastore;
   private final BaragonStateDatastore stateDatastore;
 
   @Inject
   public LoadBalancerResource(BaragonLoadBalancerDatastore loadBalancerDatastore,
+                              BaragonKnownAgentsDatastore knownAgentsDatastore,
                               BaragonStateDatastore stateDatastore) {
     this.loadBalancerDatastore = loadBalancerDatastore;
+    this.knownAgentsDatastore = knownAgentsDatastore;
     this.stateDatastore = stateDatastore;
   }
 
@@ -56,6 +60,18 @@ public class LoadBalancerResource {
   @Path("/{clusterName}/agents")
   public Collection<BaragonAgentMetadata> getAgentMetadata(@PathParam("clusterName") String clusterName) {
     return loadBalancerDatastore.getAgentMetadata(clusterName);
+  }
+
+  @GET
+  @Path("/{clusterName}/known-agents")
+  public Collection<BaragonAgentMetadata> getKnownAgentsMetadata(@PathParam("clusterName") String clusterName) {
+    return knownAgentsDatastore.getKnownAgentsMetadata(clusterName);
+  }
+
+  @DELETE
+  @Path("/{clusterName}/known-agents")
+  public void deleteKnownAgent(@PathParam("clusterName") String clusterName, @QueryParam("agentId") String agentId) {
+    knownAgentsDatastore.clearKnownAgent(clusterName, agentId);
   }
 
   @GET


### PR DESCRIPTION
@tpetr 
- Have an agent register itself when it starts up (done by hostname right now as the key, would something else be better?)
- expose an endpoint for viewing all known agents (returns a collection of agent metadata)
- expose an endpoint for deleting a known agent in the case it is removed