### PR TITLE
add option to not start baragon service worker

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -27,6 +27,7 @@ public class BaragonServiceModule extends AbstractModule {
   public static final String BARAGON_SERVICE_SCHEDULED_EXECUTOR = "baragon.service.scheduledExecutor";
   public static final String BARAGON_SERVICE_LEADER_LATCH = "baragon.service.leaderLatch";
   public static final String BARAGON_SERVICE_WORKER_INTERVAL_MS = "baragon.service.worker.intervalMs";
+  public static final String BARAGON_SERVICE_START_WORKER = "baragon.service.worker.start";
 
 
   public static final String BARAGON_SERVICE_HTTP_PORT = "baragon.service.http.port";
@@ -65,6 +66,12 @@ public class BaragonServiceModule extends AbstractModule {
   @Named(BARAGON_SERVICE_WORKER_INTERVAL_MS)
   public long provideWorkerIntervalMs(BaragonConfiguration configuration) {
     return configuration.getWorkerIntervalMs();
+  }
+
+  @Provides
+  @Named(BARAGON_SERVICE_START_WORKER)
+  public Boolean provideStartWorker(BaragonConfiguration configuration) {
+    return configuration.getStartWorker();
   }
 
   @Provides

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -28,6 +28,9 @@ public class BaragonConfiguration extends Configuration {
   @JsonProperty("workerIntervalMs")
   private long workerIntervalMs = 1000;
 
+  @JsonProperty("startWorker")
+  private Boolean startWorker = true;
+
   @JsonProperty("agentRequestUriFormat")
   @NotEmpty
   private String agentRequestUriFormat = DEFAULT_AGENT_REQUEST_URI_FORMAT;
@@ -78,6 +81,13 @@ public class BaragonConfiguration extends Configuration {
     this.workerIntervalMs = workerIntervalMs;
   }
 
+  public Boolean getStartWorker() {
+    return startWorker;
+  }
+
+  public void setStartWorker(Boolean startWorker) {
+    this.startWorker = startWorker;
+  }
   public int getAgentMaxAttempts() {
     return agentMaxAttempts;
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managed/BaragonWorkerManaged.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managed/BaragonWorkerManaged.java
@@ -24,15 +24,18 @@ public class BaragonWorkerManaged implements Managed {
   private final BaragonRequestWorker worker;
   private final LeaderLatch leaderLatch;
   private final long workerIntervalMs;
+  private final Boolean startWorker;
 
   @Inject
   public BaragonWorkerManaged(@Named(BaragonServiceModule.BARAGON_SERVICE_SCHEDULED_EXECUTOR) ScheduledExecutorService executorService,
                               @Named(BaragonServiceModule.BARAGON_SERVICE_LEADER_LATCH) LeaderLatch leaderLatch,
                               @Named(BaragonServiceModule.BARAGON_SERVICE_WORKER_INTERVAL_MS) long workerIntervalMs,
+                              @Named(BaragonServiceModule.BARAGON_SERVICE_START_WORKER) Boolean startWorker,
                               BaragonRequestWorker worker) {
     this.executorService = executorService;
     this.leaderLatch = leaderLatch;
     this.workerIntervalMs = workerIntervalMs;
+    this.startWorker = startWorker;
     this.worker = worker;
   }
 
@@ -49,7 +52,13 @@ public class BaragonWorkerManaged implements Managed {
           future.cancel(false);
         }
 
-        future = executorService.scheduleAtFixedRate(worker, 0, workerIntervalMs, TimeUnit.MILLISECONDS);
+        if (startWorker) {
+          LOG.info("Starting Baragon Service worker");
+          future = executorService.scheduleAtFixedRate(worker, 0, workerIntervalMs, TimeUnit.MILLISECONDS);
+        } else {
+          LOG.info("Not starting Baragon Service worker");
+          future.cancel(false);
+        }
       }
 
       @Override


### PR DESCRIPTION
@tpetr adds a 'startWorker' item to the possible configs (default is true)