### PR TITLE
Cleanup for solid release of cookbook to Chef Supermarket

### DIFF
--- a/cookbook/Berksfile
+++ b/cookbook/Berksfile
@@ -3,6 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'nginx'
-cookbook 'zookeeper',
-         github: 'SimpleFinance/chef-zookeeper',
-         ref: '2.5.0'
+cookbook 'zookeeper', '~> 2.5'

--- a/cookbook/Berksfile
+++ b/cookbook/Berksfile
@@ -2,5 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'nginx'
-cookbook 'zookeeper', '~> 2.5'
+group :integration do
+  cookbook 'nginx'
+  cookbook 'zookeeper', '~> 2.5'
+end

--- a/cookbook/Berksfile
+++ b/cookbook/Berksfile
@@ -2,7 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'java'
 cookbook 'nginx'
 cookbook 'zookeeper',
          github: 'SimpleFinance/chef-zookeeper',

--- a/cookbook/CHANGELOG.md
+++ b/cookbook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Baragon cookbook CHANGELOG
 
+## v1.0.1 (2015-01-21)
+
+* Clean up Berksfile
+    - Use proper release of `zookeeper` cookbook instead of GitHub release/tag
+* Add `supports` statement to metadata for Supermarket
+
 ## v1.0.0 (2015-01-18)
 
 * Initial release of baragon

--- a/cookbook/CHANGELOG.md
+++ b/cookbook/CHANGELOG.md
@@ -1,3 +1,5 @@
-# 1.0.0
+# Baragon cookbook CHANGELOG
 
-Initial release of baragon
+## v1.0.0 (2015-01-18)
+
+* Initial release of baragon

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -14,7 +14,7 @@ Baragon depends on ZooKeeper to store internal state, and perform coordination b
 
 ### Nginx
 
-Baragon write nginx-style config files by default. In theory other load balancers could be used, but the tool is designed around the style of config files used by nginx.
+Baragon writes nginx-style config files by default. In theory other load balancers could be used, but the tool is designed around the style of config files used by nginx.
 
 The main requirement is that each application and upstream has its own file containing all necessary configuration directives (as opposed to, say, haproxy, where all configuration is parsed in order from top to bottom from a single, monolithic file).
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -67,7 +67,7 @@ Include `baragon::server` in your node's `run_list`:
 }
 ```
 
-...or in a wrapper cookbook:
+…or in a wrapper cookbook:
 
 ```ruby
 include_recipe 'baragon::server'
@@ -85,7 +85,7 @@ Include `baragon::agent` in your node's `run_list`:
 }
 ```
 
-...or in a wrapper cookbook:
+…or in a wrapper cookbook:
 
 ```ruby
 include_recipe 'baragon::agent'

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -6,5 +6,7 @@ description      'Installs/Configures baragon'
 long_description 'Installs/Configures baragon'
 version          '1.0.0'
 
+supports 'ubuntu', '= 14.04'
+
 depends 'java'
 depends 'git'

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tpetr@hubspot.com'
 license          'Apache 2.0'
 description      'Installs/Configures baragon'
 long_description 'Installs/Configures baragon'
-version          '1.0.0'
+version          '1.0.1'
 
 supports 'ubuntu', '= 14.04'
 


### PR DESCRIPTION
Minor things, but nonetheless, better for a proper cookbook release.

* Specify supported platforms in metadata
* Use released versions of `zookeeper` cookbook for testing

@tpetr, soon as this merges in, I’ll ship the cookbook to the Supermarket & set you up as a contribitor. /cc @eherot