### PR TITLE
Avoid requests stuck in queue

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -29,7 +29,7 @@ import com.ning.http.client.AsyncHttpClientConfig;
 public class BaragonDataModule extends AbstractModule {
   public static final String BARAGON_AGENT_REQUEST_URI_FORMAT = "baragon.agent.request.uri.format";
   public static final String BARAGON_AGENT_MAX_ATTEMPTS = "baragon.agent.maxAttempts";
-  public static final String BARAGON_AGENT_MAX_REQUEST_TIME = "baragon.agent.maxRequestTime";
+  public static final String BARAGON_AGENT_REQUEST_TIMEOUT_MS = "baragon.agent.requestTimeoutMs";
 
   public static final String BARAGON_SERVICE_HTTP_CLIENT = "baragon.service.http.client";
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -29,6 +29,8 @@ import com.ning.http.client.AsyncHttpClientConfig;
 public class BaragonDataModule extends AbstractModule {
   public static final String BARAGON_AGENT_REQUEST_URI_FORMAT = "baragon.agent.request.uri.format";
   public static final String BARAGON_AGENT_MAX_ATTEMPTS = "baragon.agent.maxAttempts";
+  public static final String BARAGON_AGENT_MAX_REQUEST_TIME = "baragon.agent.maxRequestTime";
+
   public static final String BARAGON_SERVICE_HTTP_CLIENT = "baragon.service.http.client";
 
   public static final String BARAGON_SERVICE_WORKER_LAST_START = "baragon.service.worker.lastStartedAt";

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonAgentResponseDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonAgentResponseDatastore.java
@@ -61,14 +61,14 @@ public class BaragonAgentResponseDatastore extends AbstractDataStore {
 
   public void setPendingRequestStatus(String requestId, String baseUrl, boolean value) {
     if (value) {
-      createNode(String.format(PENDING_REQUEST_FORMAT, requestId, encodeUrl(baseUrl)));
+      writeToZk(String.format(PENDING_REQUEST_FORMAT, requestId, encodeUrl(baseUrl)), System.currentTimeMillis());
     } else {
       deleteNode(String.format(PENDING_REQUEST_FORMAT, requestId, encodeUrl(baseUrl)));
     }
   }
 
-  public boolean hasPendingRequest(String requestId, String baseUrl) {
-    return nodeExists(String.format(PENDING_REQUEST_FORMAT, requestId, encodeUrl(baseUrl)));
+  public Optional<Long> getPendingRequest(String requestId, String baseUrl) {
+    return readFromZk(String.format(PENDING_REQUEST_FORMAT, requestId, encodeUrl(baseUrl)), Long.class);
   }
 
   public Optional<AgentResponseId> getLastAgentResponseId(String requestId, AgentRequestType requestType, String baseUrl) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -59,9 +59,9 @@ public class BaragonServiceModule extends AbstractModule {
   }
 
   @Provides
-  @Named(BaragonDataModule.BARAGON_AGENT_MAX_REQUEST_TIME)
+  @Named(BaragonDataModule.BARAGON_AGENT_REQUEST_TIMEOUT_MS)
   public Long provideAgentMaxRequestTime(BaragonConfiguration configuration) {
-    return configuration.getAgentMaxRequestTime();
+    return configuration.getAgentRequestTimeoutMs();
   }
 
   @Provides

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -59,6 +59,12 @@ public class BaragonServiceModule extends AbstractModule {
   }
 
   @Provides
+  @Named(BaragonDataModule.BARAGON_AGENT_MAX_REQUEST_TIME)
+  public Long provideAgentMaxRequestTime(BaragonConfiguration configuration) {
+    return configuration.getAgentMaxRequestTime();
+  }
+
+  @Provides
   public AuthConfiguration providesAuthConfiguration(BaragonConfiguration configuration) {
     return configuration.getAuthConfiguration();
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -46,9 +46,9 @@ public class BaragonConfiguration extends Configuration {
   @Min(1)
   private int agentMaxAttempts = 5;
 
-  @JsonProperty("agentMaxRequestTime")
+  @JsonProperty("agentRequestTimeoutMs")
   @Min(10000)
-  private long agentMaxRequestTime = 60000;
+  private long agentRequestTimeoutMs = 60000;
 
   @JsonProperty("auth")
   @NotNull
@@ -97,8 +97,8 @@ public class BaragonConfiguration extends Configuration {
     return agentMaxAttempts;
   }
 
-  public long getAgentMaxRequestTime() {
-    return agentMaxRequestTime;
+  public long getAgentRequestTimeoutMs() {
+    return agentRequestTimeoutMs;
   }
 
   public void setAgentMaxAttempts(int agentMaxAttempts) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -46,6 +46,10 @@ public class BaragonConfiguration extends Configuration {
   @Min(1)
   private int agentMaxAttempts = 5;
 
+  @JsonProperty("agentMaxRequestTime")
+  @Min(10000)
+  private long agentMaxRequestTime = 60000;
+
   @JsonProperty("auth")
   @NotNull
   @Valid
@@ -91,6 +95,10 @@ public class BaragonConfiguration extends Configuration {
 
   public int getAgentMaxAttempts() {
     return agentMaxAttempts;
+  }
+
+  public long getAgentMaxRequestTime() {
+    return agentMaxRequestTime;
   }
 
   public void setAgentMaxAttempts(int agentMaxAttempts) {


### PR DESCRIPTION
@tpetr 
introduces a max request time for pending requests (defaults to 60s right now). With this check, we won't get requests stuck in the queue due to a pending request being present and the BaragonService worker processing that request having died/restarted.