### PR TITLE
Return current response when request already enqueued and matches

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/RequestAlreadyEnqueuedException.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/RequestAlreadyEnqueuedException.java
@@ -6,7 +6,8 @@ public class RequestAlreadyEnqueuedException extends Exception {
   private final String requestId;
   private final BaragonResponse response;
 
-  public RequestAlreadyEnqueuedException(String requestId, BaragonResponse response) {
+  public RequestAlreadyEnqueuedException(String requestId, BaragonResponse response, String message) {
+    super(message);
     this.requestId = requestId;
     this.response = response;
   }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -105,6 +105,7 @@ public class BaragonRequest {
     if (!loadBalancerRequestId.equals(request.loadBalancerRequestId)) return false;
     if (!loadBalancerService.equals(request.loadBalancerService)) return false;
     if (!removeUpstreams.equals(request.removeUpstreams)) return false;
+    if (!replaceServiceId.equals(request.replaceServiceId)) return false;
 
     return true;
   }
@@ -115,6 +116,7 @@ public class BaragonRequest {
     result = 31 * result + loadBalancerService.hashCode();
     result = 31 * result + addUpstreams.hashCode();
     result = 31 * result + removeUpstreams.hashCode();
+    result = 31 * result + replaceServiceId.hashCode();
     return result;
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
@@ -134,7 +134,12 @@ public class RequestManager {
     final Optional<BaragonResponse> maybePreexistingResponse = getResponse(request.getLoadBalancerRequestId());
 
     if (maybePreexistingResponse.isPresent()) {
-      throw new RequestAlreadyEnqueuedException(request.getLoadBalancerRequestId(), maybePreexistingResponse.get());
+      Optional<BaragonRequest> maybePreexistingRequest = requestDatastore.getRequest(request.getLoadBalancerRequestId());
+      if (maybePreexistingRequest.isPresent() && !maybePreexistingRequest.get().equals(request)) {
+        throw new RequestAlreadyEnqueuedException(request.getLoadBalancerRequestId(), maybePreexistingResponse.get(), String.format("Request %s is already enqueued with different parameters", request.getLoadBalancerRequestId()));
+      } else {
+        return maybePreexistingResponse.get();
+      }
     }
 
     requestDatastore.addRequest(request);


### PR DESCRIPTION
@tpetr
This returns the current response if the request is equal to the previous one with the same id, otherwise it returns a failed response with a message that the request is already enqueued with different parameters.