### PR TITLE
ignore extra template fields

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/TemplateConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/TemplateConfiguration.java
@@ -1,10 +1,12 @@
 package com.hubspot.baragon.agent.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TemplateConfiguration {
   @NotEmpty
   @JsonProperty("filename")


### PR DESCRIPTION
@tpetr in prep for adding support for additional templates, this will ignore the extra fields so agents without the additional support can start properly