### PR TITLE
Customizable jar name

### DIFF
--- a/BaragonAgentService/pom.xml
+++ b/BaragonAgentService/pom.xml
@@ -91,6 +91,7 @@
         <version>${java.abi}</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
+          <finalName>${baragon.jar.name.format}</finalName>
           <filters>
             <filter>
               <artifact>*:*</artifact>

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <dropwizard.serviceClass>com.hubspot.baragon.service.BaragonService</dropwizard.serviceClass>
-        <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
     </properties>
 
 	<dependencies>

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <dropwizard.serviceClass>com.hubspot.baragon.service.BaragonService</dropwizard.serviceClass>
+        <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
     </properties>
 
 	<dependencies>
@@ -79,6 +80,7 @@
         <version>${java.abi}</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
+          <finalName>${baragon.jar.name.format}</finalName>
           <filters>
             <filter>
               <artifact>*:*</artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <dropwizard.version>0.7.0</dropwizard.version>
     <horizon.version>0.0.10</horizon.version>
     <junit.version>4.11</junit.version>
+    <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
 </properties>
 
 <groupId>com.hubspot</groupId>


### PR DESCRIPTION
This keeps the current JAR name format for backwards-compatibility while allowing us to override it with something like `-Dbaragon.jar.name.format=${project.artifactId}`

@tpetr @ssalinas 