### PR TITLE
add success message when request is completed

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/worker/BaragonRequestWorker.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/worker/BaragonRequestWorker.java
@@ -107,6 +107,7 @@ public class BaragonRequestWorker implements Runnable {
             return InternalRequestStates.FAILED_SEND_REVERT_REQUESTS;
           case SUCCESS:
             try {
+              requestManager.setRequestMessage(request.getLoadBalancerRequestId(), String.format("%s request succeeded! Added upstreams: %s, Removed upstreams: %s", InternalStatesMap.getRequestType(currentState), request.getAddUpstreams(), request.getRemoveUpstreams()));
               requestManager.commitRequest(request);
               return InternalRequestStates.COMPLETED;
             } catch (Exception e) {


### PR DESCRIPTION
Sets the message after a successful request so the message isn't still 'Queued as....'

/cc @tpetr 