### PR TITLE
return failure not noop for missing template exception

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/AgentManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/AgentManager.java
@@ -180,8 +180,8 @@ public class AgentManager {
       }
     }
 
-    if (allTrue(missingTemplateExceptions)) {
-      return AgentRequestsStatus.INVALID_REQUEST_NOOP;
+    if (!missingTemplateExceptions.isEmpty() && allTrue(missingTemplateExceptions)) {
+      return AgentRequestsStatus.FAILURE;
     }
 
     return success ? AgentRequestsStatus.SUCCESS : AgentRequestsStatus.FAILURE;


### PR DESCRIPTION
fixes the case of removing from one group and adding to a second group with no active agents