### PR TITLE
add upstream override functionality

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -151,8 +151,8 @@ public class AgentRequestManager {
   private ServiceContext getApplyContext(BaragonRequest request) throws Exception {
     if (movedOffLoadBalancer(request)) {
       return new ServiceContext(request.getLoadBalancerService(), Collections.<UpstreamInfo>emptyList(), System.currentTimeMillis(), false);
-    } else if (request.getOverrideUpstreams().isPresent()) {
-      return new ServiceContext(request.getLoadBalancerService(), request.getOverrideUpstreams().get(), System.currentTimeMillis(), true);
+    } else if (!request.getReplaceUpstreams().isEmpty()) {
+      return new ServiceContext(request.getLoadBalancerService(), request.getReplaceUpstreams(), System.currentTimeMillis(), true);
     } else {
       final Map<String, UpstreamInfo> upstreamsMap = new HashMap<>();
       upstreamsMap.putAll(stateDatastore.getUpstreamsMap(request.getLoadBalancerService().getServiceId()));

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -151,6 +151,8 @@ public class AgentRequestManager {
   private ServiceContext getApplyContext(BaragonRequest request) throws Exception {
     if (movedOffLoadBalancer(request)) {
       return new ServiceContext(request.getLoadBalancerService(), Collections.<UpstreamInfo>emptyList(), System.currentTimeMillis(), false);
+    } else if (request.getOverrideUpstreams().isPresent()) {
+      return new ServiceContext(request.getLoadBalancerService(), request.getOverrideUpstreams().get(), System.currentTimeMillis(), true);
     } else {
       final Map<String, UpstreamInfo> upstreamsMap = new HashMap<>();
       upstreamsMap.putAll(stateDatastore.getUpstreamsMap(request.getLoadBalancerService().getServiceId()));

--- a/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/InvalidUpstreamsException.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/InvalidUpstreamsException.java
@@ -1,0 +1,7 @@
+package com.hubspot.baragon.exceptions;
+
+public class InvalidUpstreamsException extends Exception {
+  public InvalidUpstreamsException(String message) {
+    super(message);
+  }
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -9,6 +9,9 @@ import com.google.common.collect.Lists;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
@@ -31,11 +34,14 @@ public class BaragonRequest {
 
   private final Optional<RequestAction> action;
 
+  private final Optional<List<UpstreamInfo>> overrideUpstreams;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
                         @JsonProperty("addUpstreams") List<UpstreamInfo> addUpstreams,
                         @JsonProperty("removeUpstreams") List<UpstreamInfo> removeUpstreams,
+                        @JsonProperty("overrideUpstreams") Optional<List<UpstreamInfo>> overrideUpstreams,
                         @JsonProperty("replaceServiceId") Optional<String> replaceServiceId,
                         @JsonProperty("action") Optional<RequestAction> action) {
     this.loadBalancerRequestId = loadBalancerRequestId;
@@ -44,14 +50,15 @@ public class BaragonRequest {
     this.removeUpstreams = addRequestId(removeUpstreams, loadBalancerRequestId);
     this.replaceServiceId = replaceServiceId;
     this.action = action;
+    this.overrideUpstreams = overrideUpstreams;
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Optional.<String>absent(), Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Optional.<List<UpstreamInfo>>absent(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE));
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceServiceId, Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Optional.<List<UpstreamInfo>>absent(), replaceServiceId, Optional.of(RequestAction.UPDATE));
   }
 
   public String getLoadBalancerRequestId() {
@@ -68,6 +75,10 @@ public class BaragonRequest {
 
   public List<UpstreamInfo> getRemoveUpstreams() {
     return removeUpstreams;
+  }
+
+  public Optional<List<UpstreamInfo>> getOverrideUpstreams() {
+    return overrideUpstreams;
   }
 
   public Optional<String> getReplaceServiceId() {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -3,6 +3,7 @@ package com.hubspot.baragon.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
@@ -10,7 +11,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,14 +34,14 @@ public class BaragonRequest {
 
   private final Optional<RequestAction> action;
 
-  private final Optional<List<UpstreamInfo>> overrideUpstreams;
+  private final List<UpstreamInfo> replaceUpstreams;
 
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
                         @JsonProperty("addUpstreams") List<UpstreamInfo> addUpstreams,
                         @JsonProperty("removeUpstreams") List<UpstreamInfo> removeUpstreams,
-                        @JsonProperty("overrideUpstreams") Optional<List<UpstreamInfo>> overrideUpstreams,
+                        @JsonProperty("overrideUpstreams") List<UpstreamInfo> replaceUpstreams,
                         @JsonProperty("replaceServiceId") Optional<String> replaceServiceId,
                         @JsonProperty("action") Optional<RequestAction> action) {
     this.loadBalancerRequestId = loadBalancerRequestId;
@@ -50,15 +50,15 @@ public class BaragonRequest {
     this.removeUpstreams = addRequestId(removeUpstreams, loadBalancerRequestId);
     this.replaceServiceId = replaceServiceId;
     this.action = action;
-    this.overrideUpstreams = overrideUpstreams;
+    this.replaceUpstreams = Objects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Optional.<List<UpstreamInfo>>absent(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE));
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Optional.<List<UpstreamInfo>>absent(), replaceServiceId, Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE));
   }
 
   public String getLoadBalancerRequestId() {
@@ -77,8 +77,8 @@ public class BaragonRequest {
     return removeUpstreams;
   }
 
-  public Optional<List<UpstreamInfo>> getOverrideUpstreams() {
-    return overrideUpstreams;
+  public List<UpstreamInfo> getReplaceUpstreams() {
+    return replaceUpstreams;
   }
 
   public Optional<String> getReplaceServiceId() {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -95,6 +95,15 @@ public class BaragonStateDatastore extends AbstractDataStore {
     }
   }
 
+  public void setUpstreams(String serviceId, Collection<UpstreamInfo> upstreams) throws Exception {
+    for (UpstreamInfo upstreamInfo : getUpstreamsMap(serviceId).values()) {
+      deleteNode(String.format(UPSTREAM_FORMAT, serviceId, sanitizeNodeName(upstreamInfo.getUpstream())));
+    }
+    for (UpstreamInfo upstreamInfo : upstreams) {
+      writeToZk(String.format(UPSTREAM_FORMAT, serviceId, sanitizeNodeName(upstreamInfo.getUpstream())), upstreamInfo);
+    }
+  }
+
   public void updateStateNode() {
     try {
       LOG.info("Starting state node update");

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
@@ -145,7 +145,7 @@ public class RequestManager {
       }
     }
 
-    if (request.getOverrideUpstreams().isPresent() && (!request.getAddUpstreams().isEmpty() || !request.getRemoveUpstreams().isEmpty())) {
+    if (!request.getReplaceUpstreams().isEmpty() && (!request.getAddUpstreams().isEmpty() || !request.getRemoveUpstreams().isEmpty())) {
       throw new InvalidUpstreamsException("If overrideUpstreams is specified, addUpstreams and removeUpstreams mustbe empty");
     }
 
@@ -222,8 +222,8 @@ public class RequestManager {
   private void updateStateDatastore(BaragonRequest request) {
     try {
       stateDatastore.addService(request.getLoadBalancerService());
-      if (request.getOverrideUpstreams().isPresent()) {
-        stateDatastore.setUpstreams(request.getLoadBalancerService().getServiceId(), request.getOverrideUpstreams().get());
+      if (!request.getReplaceUpstreams().isEmpty()) {
+        stateDatastore.setUpstreams(request.getLoadBalancerService().getServiceId(), request.getReplaceUpstreams());
       } else {
         stateDatastore.removeUpstreams(request.getLoadBalancerService().getServiceId(), request.getRemoveUpstreams());
         stateDatastore.addUpstreams(request.getLoadBalancerService().getServiceId(), request.getAddUpstreams());

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/RequestManager.java
@@ -15,6 +15,7 @@ import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.data.BaragonRequestDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.exceptions.InvalidRequestActionException;
+import com.hubspot.baragon.exceptions.InvalidUpstreamsException;
 import com.hubspot.baragon.exceptions.RequestAlreadyEnqueuedException;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonResponse;
@@ -132,7 +133,7 @@ public class RequestManager {
     }
   }
 
-  public BaragonResponse enqueueRequest(BaragonRequest request) throws RequestAlreadyEnqueuedException, InvalidRequestActionException {
+  public BaragonResponse enqueueRequest(BaragonRequest request) throws RequestAlreadyEnqueuedException, InvalidRequestActionException, InvalidUpstreamsException {
     final Optional<BaragonResponse> maybePreexistingResponse = getResponse(request.getLoadBalancerRequestId());
 
     if (maybePreexistingResponse.isPresent()) {
@@ -142,6 +143,10 @@ public class RequestManager {
       } else {
         return maybePreexistingResponse.get();
       }
+    }
+
+    if (request.getOverrideUpstreams().isPresent() && (!request.getAddUpstreams().isEmpty() || !request.getRemoveUpstreams().isEmpty())) {
+      throw new InvalidUpstreamsException("If overrideUpstreams is specified, addUpstreams and removeUpstreams mustbe empty");
     }
 
     if (request.getAction().isPresent() && request.getAction().equals(Optional.of(RequestAction.REVERT))) {
@@ -215,10 +220,18 @@ public class RequestManager {
   }
 
   private void updateStateDatastore(BaragonRequest request) {
-    stateDatastore.addService(request.getLoadBalancerService());
-    stateDatastore.removeUpstreams(request.getLoadBalancerService().getServiceId(), request.getRemoveUpstreams());
-    stateDatastore.addUpstreams(request.getLoadBalancerService().getServiceId(), request.getAddUpstreams());
-    stateDatastore.updateStateNode();
+    try {
+      stateDatastore.addService(request.getLoadBalancerService());
+      if (request.getOverrideUpstreams().isPresent()) {
+        stateDatastore.setUpstreams(request.getLoadBalancerService().getServiceId(), request.getOverrideUpstreams().get());
+      } else {
+        stateDatastore.removeUpstreams(request.getLoadBalancerService().getServiceId(), request.getRemoveUpstreams());
+        stateDatastore.addUpstreams(request.getLoadBalancerService().getServiceId(), request.getAddUpstreams());
+      }
+      stateDatastore.updateStateNode();
+    } catch (Exception e) {
+      LOG.error(String.format("Error updating state datastore %s", e));
+    }
   }
 
   private void removeOldService(BaragonRequest request, Optional<BaragonService> maybeOriginalService) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/ServiceManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/ServiceManager.java
@@ -76,11 +76,11 @@ public class ServiceManager {
     List<UpstreamInfo> empty = Collections.emptyList();
     List<UpstreamInfo> remove;
     remove =  new ArrayList<>(stateDatastore.getUpstreamsMap(service.getServiceId()).values());
-    return new BaragonRequest(requestId, service, empty, remove, Optional.<String>absent(), Optional.of(RequestAction.DELETE));
+    return new BaragonRequest(requestId, service, empty, remove, Optional.<List<UpstreamInfo>>absent(), Optional.<String>absent(), Optional.of(RequestAction.DELETE));
   }
 
   private BaragonRequest buildReloadRequest(BaragonService service, String requestId) {
     List<UpstreamInfo> empty = Collections.emptyList();
-    return new BaragonRequest(requestId, service, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD));
+    return new BaragonRequest(requestId, service, empty, empty, Optional.<List<UpstreamInfo>>absent(), Optional.<String>absent(), Optional.of(RequestAction.RELOAD));
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/ServiceManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/ServiceManager.java
@@ -76,11 +76,11 @@ public class ServiceManager {
     List<UpstreamInfo> empty = Collections.emptyList();
     List<UpstreamInfo> remove;
     remove =  new ArrayList<>(stateDatastore.getUpstreamsMap(service.getServiceId()).values());
-    return new BaragonRequest(requestId, service, empty, remove, Optional.<List<UpstreamInfo>>absent(), Optional.<String>absent(), Optional.of(RequestAction.DELETE));
+    return new BaragonRequest(requestId, service, empty, remove, empty, Optional.<String>absent(), Optional.of(RequestAction.DELETE));
   }
 
   private BaragonRequest buildReloadRequest(BaragonService service, String requestId) {
     List<UpstreamInfo> empty = Collections.emptyList();
-    return new BaragonRequest(requestId, service, empty, empty, Optional.<List<UpstreamInfo>>absent(), Optional.<String>absent(), Optional.of(RequestAction.RELOAD));
+    return new BaragonRequest(requestId, service, empty, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD));
   }
 }

--- a/BaragonData/src/test/java/com/hubspot/baragon/RequestTests.java
+++ b/BaragonData/src/test/java/com/hubspot/baragon/RequestTests.java
@@ -1,6 +1,7 @@
 package com.hubspot.baragon;
 
 import com.hubspot.baragon.exceptions.InvalidRequestActionException;
+import com.hubspot.baragon.exceptions.InvalidUpstreamsException;
 import org.jukito.JukitoModule;
 import org.jukito.JukitoRunner;
 import org.junit.After;
@@ -176,7 +177,7 @@ public class RequestTests {
   }
 
   @Test(expected = RequestAlreadyEnqueuedException.class)
-  public void testPreexistingResponse(RequestManager requestManager) throws RequestAlreadyEnqueuedException, InvalidRequestActionException {
+  public void testPreexistingResponse(RequestManager requestManager) throws RequestAlreadyEnqueuedException, InvalidRequestActionException, InvalidUpstreamsException {
     final String requestId = "test-127";
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(FAKE_LB_GROUP);


### PR DESCRIPTION
Add an override upstreams functionality for systems that may have to concept of the previously running upstreams to add or remove, implemented so that it will error if `overrideUpstreams` is set and `addUpstreams`/`removeUpstreams` are not empty