### PR TITLE
Switch to HubSpot basepom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </developers>
 
   <properties>
-    <horizon.version>0.0.14</horizon.version>           
+    <horizon.version>0.0.13</horizon.version>           
     <ringleader.version>0.1.4</ringleader.version>           
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>10.5</version>
+    <version>10.6</version>
   </parent>
 
   <artifactId>Baragon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>10.6</version>
+    <version>10.7</version>
   </parent>
 
   <artifactId>Baragon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
   </developers>
 
   <properties>
+    <horizon.version>0.0.14</horizon.version>           
+    <ringleader.version>0.1.4</ringleader.version>           
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
   </properties>
 
@@ -83,31 +85,31 @@
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>HorizonCore</artifactId>
-        <version>0.0.13</version>
+        <version>${horizon.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>HorizonApache</artifactId>
-        <version>0.0.13</version>
+        <version>${horizon.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>HorizonNing</artifactId>
-        <version>0.0.13</version>
+        <version>${horizon.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.hubspot.dropwizard</groupId>
         <artifactId>dropwizard-guice</artifactId>
-        <version>0.7.1</version>
+        <version>${dropwizard.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>Ringleader</artifactId>
-        <version>0.1.4</version>
+        <version>${ringleader.version}</version>
       </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>10.4</version>
+    <version>10.5</version>
   </parent>
 
   <artifactId>Baragon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,15 +82,17 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- Dropwizard -->
+      <dependency>
+        <groupId>com.hubspot.dropwizard</groupId>
+        <artifactId>dropwizard-guice</artifactId>
+        <version>${dropwizard.version}</version>
+      </dependency>
+
+      <!-- Horizon -->
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>HorizonCore</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonApache</artifactId>
         <version>${horizon.version}</version>
       </dependency>
 
@@ -101,11 +103,12 @@
       </dependency>
 
       <dependency>
-        <groupId>com.hubspot.dropwizard</groupId>
-        <artifactId>dropwizard-guice</artifactId>
-        <version>${dropwizard.version}</version>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonApache</artifactId>
+        <version>${horizon.version}</version>
       </dependency>
 
+      <!-- Ringleader -->
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>Ringleader</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>10.2</version>
+    <version>10.4</version>
   </parent>
 
   <artifactId>Baragon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,36 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonCore</artifactId>
+        <version>0.0.13</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonApache</artifactId>
+        <version>0.0.13</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonNing</artifactId>
+        <version>0.0.13</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.hubspot.dropwizard</groupId>
+        <artifactId>dropwizard-guice</artifactId>
+        <version>0.7.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>Ringleader</artifactId>
+        <version>0.1.4</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.basepom</groupId>
-    <artifactId>basepom-standard-oss</artifactId>
-    <version>10</version>
+    <groupId>com.hubspot</groupId>
+    <artifactId>basepom</artifactId>
+    <version>10.1</version>
   </parent>
 
-  <groupId>com.hubspot</groupId>
   <artifactId>Baragon</artifactId>
   <version>0.1.7-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -30,42 +29,6 @@
   </developers>
 
   <properties>
-    <project.jdk7.home>${env.JAVA_HOME}</project.jdk7.home>
-    <project.build.targetJdk>1.7</project.build.targetJdk>
-    <basepom.check.skip-license>true</basepom.check.skip-license>
-
-    <basepom.test.timeout>120</basepom.test.timeout>
-
-    <!-- hubspot jackson and dropwizard dep use 2.3.x -->
-    <dep.jackson.version>2.5.1</dep.jackson.version>
-    <dep.jackson.core.version>${dep.jackson.version}</dep.jackson.core.version>
-    <dep.jackson.databind.version>${dep.jackson.version}</dep.jackson.databind.version>
-
-    <!-- guava 18.0 is problematic, keep 17 for a while -->
-    <dep.guava.version>17.0</dep.guava.version>
-
-    <!-- dropwizard uses jetty 9.0.x -->
-    <dep.jetty.version>9.0.7.v20131107</dep.jetty.version>
-
-    <dep.metrics.version>3.0.2</dep.metrics.version>
-    <dep.zookeeper.version>3.4.6</dep.zookeeper.version>
-
-    <dep.jesos.version>1.1</dep.jesos.version>
-
-    <curator.version>2.7.1</curator.version>
-    <dropwizard.version>0.7.1</dropwizard.version>
-    <jets3t.version>0.9.0</jets3t.version>
-    <mesos.version>0.21.0</mesos.version>
-    <ning.async.version>1.8.12</ning.async.version>
-    <snappy.version>0.3</snappy.version>
-    <sentry.version>5.0</sentry.version>
-    <horizon.version>0.0.13</horizon.version>
-    <commons-exec.version>1.1</commons-exec.version>
-    <jukito.version>1.3</jukito.version>
-    <hibernate.version>5.1.1.Final</hibernate.version>
-    <handlebars.version>1.3.1</handlebars.version>
-    <ringleader.version>0.1.1</ringleader.version>
-    <aws.sdk.version>1.9.37</aws.sdk.version>
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
   </properties>
 
@@ -117,355 +80,30 @@
         <version>${project.version}</version>
       </dependency>
 
-      <!-- Dropwizard -->
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-core</artifactId>
-        <version>${dropwizard.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.eclipse.jetty.orbit</groupId>
-            <artifactId>javax.servlet</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-jackson</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-jetty</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-continuation</artifactId>
-        <version>${dep.jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-jersey</artifactId>
-        <version>${dropwizard.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.eclipse.jetty.orbit</groupId>
-            <artifactId>javax.servlet</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-lifecycle</artifactId>
-        <version>${dropwizard.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-servlets</artifactId>
-        <version>${dropwizard.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.eclipse.jetty.orbit</groupId>
-            <artifactId>javax.servlet</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hubspot.dropwizard</groupId>
-        <artifactId>dropwizard-guice</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-views</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-views-mustache</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-assets</artifactId>
-        <version>${dropwizard.version}</version>
-      </dependency>
-
-      <!-- Metrics -->
-      <dependency>
-        <groupId>com.codahale.metrics</groupId>
-        <artifactId>metrics-healthchecks</artifactId>
-        <version>${dep.metrics.version}</version>
-      </dependency>
-
-      <!-- Horizon -->
-      <dependency>
-        <groupId>com.ning</groupId>
-        <artifactId>async-http-client</artifactId>
-        <version>${ning.async.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonCore</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonNing</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonApache</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-
-      <!-- Hibernate -->
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-validator</artifactId>
-        <version>${hibernate.version}</version>
-      </dependency>
-
-      <!-- Handlebars -->
-      <dependency>
-        <groupId>com.github.jknack</groupId>
-        <artifactId>handlebars</artifactId>
-        <version>${handlebars.version}</version>
-      </dependency>
-
-      <!-- Curator -->
-      <dependency>
-        <groupId>org.apache.zookeeper</groupId>
-        <artifactId>zookeeper</artifactId>
-        <version>${dep.zookeeper.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <artifactId>log4j</artifactId>
-            <groupId>log4j</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jline</artifactId>
-            <groupId>jline</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>netty</artifactId>
-            <groupId>io.netty</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-client</artifactId>
-        <version>${curator.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-framework</artifactId>
-        <version>${curator.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-recipes</artifactId>
-        <version>${curator.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-test</artifactId>
-        <version>${curator.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <!-- Ringleader -->
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>Ringleader</artifactId>
-        <version>${ringleader.version}</version>
-      </dependency>
-
-      <!-- Commons Exec -->
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-exec</artifactId>
-        <version>${commons-exec.version}</version>
-      </dependency>
-
-      <!-- Jukito (testing) -->
-      <dependency>
-        <groupId>org.jukito</groupId>
-        <artifactId>jukito</artifactId>
-        <version>${jukito.version}</version>
-      </dependency>
-
-      <!-- AWS SDK -->
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-core</artifactId>
-        <version>${aws.sdk.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-elasticloadbalancing</artifactId>
-        <version>${aws.sdk.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-core</artifactId>
-        <version>${aws.sdk.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 
-  <profiles>
-    <profile>
-      <id>travis</id>
-      <activation>
-        <property>
-          <name>env.TRAVIS</name>
-        </property>
-      </activation>
-      <properties>
-        <project.jdk7.home>${env.JAVA_HOME}</project.jdk7.home>
-        <basepom.test.reuse-vm>false</basepom.test.reuse-vm>
-        <basepom.test.fork-count>1</basepom.test.fork-count>
-      </properties>
-    </profile>
-    <profile>
-      <id>cross-compile</id>
-      <activation>
-        <jdk>(1.7,]</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <compilerArguments children.combine="append">
-                  <bootclasspath>
-                    ${project.jdk7.home}/jre/lib/rt.jar:${project.jdk7.home}/jre/lib/jce.jar:${project.jdk7.home}/../classes/classes.jar
-                  </bootclasspath>
-                </compilerArguments>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <bootclasspath>
-                  ${project.jdk7.home}/jre/lib/rt.jar:${project.jdk7.home}/jre/lib/jce.jar:${project.jdk7.home}/../classes/classes.jar
-                </bootclasspath>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <configuration>
-                <createDependencyReducedPom>true</createDependencyReducedPom>
-                <finalName>${baragon.jar.name.format}</finalName>
-              </configuration>
-              <executions>
-                <execution>
-                  <phase>package</phase>
-                  <goals>
-                    <goal>shade</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <configuration>
+            <createDependencyReducedPom>true</createDependencyReducedPom>
+            <finalName>${baragon.jar.name.format}</finalName>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>10.1</version>
+    <version>10.2</version>
   </parent>
 
   <artifactId>Baragon</artifactId>


### PR DESCRIPTION
Would like to use [HubSpot/basepom](https://github.com/HubSpot/basepom) as the parent on all of our opensource projects to more sanely manage dependencies across all of them

@tpetr @ssalinas 