### PR TITLE
non-existent response should be RETRY not WAITING status

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/AgentManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/AgentManager.java
@@ -164,7 +164,7 @@ public class AgentManager {
       final Optional<AgentResponseId> maybeAgentResponseId = agentResponseDatastore.getLastAgentResponseId(request.getLoadBalancerRequestId(), requestType, baseUrl);
 
       if (!maybeAgentResponseId.isPresent()) {
-        return AgentRequestsStatus.WAITING;
+        return AgentRequestsStatus.RETRY;
       }
 
       Optional<AgentResponse> maybeLastResponse = agentResponseDatastore.getAgentResponse(request.getLoadBalancerRequestId(), requestType, maybeAgentResponseId.get(), baseUrl);


### PR DESCRIPTION
keeps a request from getting stuck when an agent is added as the request is being processed

@tpetr 