### PR TITLE
Stay in sync after losing connection

### DIFF
--- a/BaragonAgentService/pom.xml
+++ b/BaragonAgentService/pom.xml
@@ -64,8 +64,16 @@
       <artifactId>validation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/BaragonAgentService/pom.xml
+++ b/BaragonAgentService/pom.xml
@@ -123,6 +123,10 @@
       <groupId>com.github.rholder</groupId>
       <artifactId>guava-retrying</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -55,7 +55,6 @@ public class BaragonAgentServiceModule extends AbstractModule {
   public static final String DEFAULT_TEMPLATE_NAME = "default";
   public static final String BARAGON_AGENT_HTTP_CLIENT = "baragon.agent.http.client";
 
-
   @Override
   protected void configure() {
     install(new BaragonDataModule());

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -24,10 +24,12 @@ import com.hubspot.baragon.agent.config.TemplateConfiguration;
 import com.hubspot.baragon.agent.config.TestingConfiguration;
 import com.hubspot.baragon.agent.handlebars.FirstOfHelper;
 import com.hubspot.baragon.agent.handlebars.FormatTimestampHelper;
+import com.hubspot.baragon.agent.listeners.ResyncListener;
 import com.hubspot.baragon.agent.models.LbConfigTemplate;
 import com.hubspot.baragon.config.AuthConfiguration;
 import com.hubspot.baragon.config.HttpClientConfiguration;
 import com.hubspot.baragon.config.ZooKeeperConfiguration;
+import com.hubspot.baragon.data.BaragonConnectionStateListener;
 import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.models.BaragonAgentEc2Metadata;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
@@ -37,7 +39,10 @@ import com.hubspot.horizon.HttpConfig;
 import com.hubspot.horizon.apache.ApacheHttpClient;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.SimpleServerFactory;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 
 public class BaragonAgentServiceModule extends AbstractModule {
   public static final String AGENT_SCHEDULED_EXECUTOR = "baragon.service.scheduledExecutor";
@@ -188,4 +193,20 @@ public class BaragonAgentServiceModule extends AbstractModule {
     return new ApacheHttpClient(configBuilder.build());
   }
 
+  @Singleton
+  @Provides
+  public CuratorFramework provideCurator(ZooKeeperConfiguration config, BaragonConnectionStateListener connectionStateListener, ResyncListener resyncListener) {
+    CuratorFramework client = CuratorFrameworkFactory.newClient(
+      config.getQuorum(),
+      config.getSessionTimeoutMillis(),
+      config.getConnectTimeoutMillis(),
+      new ExponentialBackoffRetry(config.getRetryBaseSleepTimeMilliseconds(), config.getRetryMaxTries()));
+
+    client.getConnectionStateListenable().addListener(connectionStateListener);
+    client.getConnectionStateListenable().addListener(resyncListener);
+
+    client.start();
+
+    return client.usingNamespace(config.getZkNamespace());
+  }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/ServerProvider.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/ServerProvider.java
@@ -2,9 +2,8 @@ package com.hubspot.baragon.agent;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.inject.Inject;
-
 import com.google.common.base.Optional;
+import com.google.inject.Inject;
 import com.google.inject.Provider;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import org.eclipse.jetty.server.Server;

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/ServerProvider.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/ServerProvider.java
@@ -1,0 +1,29 @@
+package com.hubspot.baragon.agent;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.inject.Inject;
+
+import com.google.common.base.Optional;
+import com.google.inject.Provider;
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import org.eclipse.jetty.server.Server;
+
+public class ServerProvider implements Provider<Optional<Server>>, ServerLifecycleListener
+{
+  private final AtomicReference<Server> serverHolder = new AtomicReference<>();
+
+  @Inject
+  public ServerProvider() {
+  }
+
+  @Override
+  public Optional<Server> get() {
+    return Optional.fromNullable(serverHolder.get());
+  }
+
+  @Override
+  public void serverStarted(Server server) {
+    serverHolder.set(server);
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -87,6 +87,9 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("stateFile")
   private Optional<String> stateFile = Optional.absent();
 
+  @JsonProperty("maxReapplyConfigAttempts")
+  private int maxReapplyConfigAttempts = 3;
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -225,5 +228,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setStateFile(Optional<String> stateFile) {
     this.stateFile = stateFile;
+  }
+
+  public int getMaxReapplyConfigAttempts() {
+    return maxReapplyConfigAttempts;
+  }
+
+  public void setMaxReapplyConfigAttempts(int maxReapplyConfigAttempts) {
+    this.maxReapplyConfigAttempts = maxReapplyConfigAttempts;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.agent.listeners;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
 import ch.qos.logback.classic.LoggerContext;
@@ -16,6 +17,7 @@ import com.hubspot.baragon.agent.BaragonAgentServiceModule;
 import com.hubspot.baragon.agent.ServerProvider;
 import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
 import com.hubspot.baragon.agent.managed.LifecycleHelper;
+import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.exceptions.ReapplyFailedException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.state.ConnectionState;
@@ -32,26 +34,36 @@ public class ResyncListener implements ConnectionStateListener {
 
   private final LifecycleHelper lifecycleHelper;
   private final ServerProvider serverProvider;
+  private final BaragonLoadBalancerDatastore loadBalancerDatastore;
   private final Lock agentLock;
   private final long agentLockTimeoutMs;
+  private final AtomicReference<String> mostRecentRequestId;
 
   @Inject
   public ResyncListener(LifecycleHelper lifecycleHelper,
                         BaragonAgentConfiguration configuration,
                         ServerProvider serverProvider,
+                        BaragonLoadBalancerDatastore loadBalancerDatastore,
                         @Named(BaragonAgentServiceModule.AGENT_LOCK) Lock agentLock,
-                        @Named(BaragonAgentServiceModule.AGENT_LOCK_TIMEOUT_MS) long agentLockTimeoutMs) {
+                        @Named(BaragonAgentServiceModule.AGENT_LOCK_TIMEOUT_MS) long agentLockTimeoutMs,
+                        @Named(BaragonAgentServiceModule.AGENT_MOST_RECENT_REQUEST_ID) AtomicReference<String> mostRecentRequestId) {
     this.lifecycleHelper = lifecycleHelper;
     this.configuration = configuration;
     this.serverProvider = serverProvider;
+    this.loadBalancerDatastore = loadBalancerDatastore;
     this.agentLock = agentLock;
     this.agentLockTimeoutMs = agentLockTimeoutMs;
+    this.mostRecentRequestId = mostRecentRequestId;
   }
 
   @Override
   public void stateChanged(CuratorFramework client, ConnectionState newState) {
     if (newState.equals(ConnectionState.RECONNECTED)) {
-      reapplyConfigsWithRetry();
+      LOG.info("Reconnected to zookeeper, checking if configs are still in sync");
+      Optional<String> maybeLastReuqestForGroup = loadBalancerDatastore.getLastRequestForGroup(configuration.getLoadBalancerConfiguration().getName());
+      if (!maybeLastReuqestForGroup.isPresent() || maybeLastReuqestForGroup.get().equals(mostRecentRequestId.get())) {
+        reapplyConfigsWithRetry();
+      }
     }
   }
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -59,10 +59,10 @@ public class ResyncListener implements ConnectionStateListener {
 
   @Override
   public void stateChanged(CuratorFramework client, ConnectionState newState) {
-    if (newState.equals(ConnectionState.RECONNECTED)) {
+    if (newState == ConnectionState.RECONNECTED) {
       LOG.info("Reconnected to zookeeper, checking if configs are still in sync");
-      Optional<String> maybeLastReuqestForGroup = loadBalancerDatastore.getLastRequestForGroup(configuration.getLoadBalancerConfiguration().getName());
-      if (!maybeLastReuqestForGroup.isPresent() || !maybeLastReuqestForGroup.get().equals(mostRecentRequestId.get())) {
+      Optional<String> maybeLastRequestForGroup = loadBalancerDatastore.getLastRequestForGroup(configuration.getLoadBalancerConfiguration().getName());
+      if (!maybeLastRequestForGroup.isPresent() || !maybeLastRequestForGroup.get().equals(mostRecentRequestId.get())) {
         reapplyConfigsWithRetry();
       }
     }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -62,7 +62,7 @@ public class ResyncListener implements ConnectionStateListener {
     if (newState.equals(ConnectionState.RECONNECTED)) {
       LOG.info("Reconnected to zookeeper, checking if configs are still in sync");
       Optional<String> maybeLastReuqestForGroup = loadBalancerDatastore.getLastRequestForGroup(configuration.getLoadBalancerConfiguration().getName());
-      if (!maybeLastReuqestForGroup.isPresent() || maybeLastReuqestForGroup.get().equals(mostRecentRequestId.get())) {
+      if (!maybeLastReuqestForGroup.isPresent() || !maybeLastReuqestForGroup.get().equals(mostRecentRequestId.get())) {
         reapplyConfigsWithRetry();
       }
     }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -90,6 +90,8 @@ public class ResyncListener implements ConnectionStateListener {
       retryer.call(callable);
     } catch (Exception e) {
       abort(e);
+    } finally {
+      agentLock.unlock();
     }
   }
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -1,0 +1,136 @@
+package com.hubspot.baragon.agent.listeners;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.base.Optional;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.hubspot.baragon.agent.BaragonAgentServiceModule;
+import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
+import com.hubspot.baragon.agent.lbs.BootstrapFileChecker;
+import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
+import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.exceptions.ReapplyFailedException;
+import com.hubspot.baragon.models.BaragonConfigFile;
+import com.hubspot.baragon.models.BaragonServiceState;
+import com.hubspot.baragon.models.ServiceContext;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResyncListener implements ConnectionStateListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ResyncListener.class);
+
+  private final BaragonAgentConfiguration configuration;
+  private final FilesystemConfigHelper configHelper;
+  private final BaragonStateDatastore stateDatastore;
+  private final Lock agentLock;
+  private final long agentLockTimeoutMs;
+
+  @Inject
+  public ResyncListener(BaragonStateDatastore stateDatastore,
+                        FilesystemConfigHelper configHelper,
+                        BaragonAgentConfiguration configuration,
+                        @Named(BaragonAgentServiceModule.AGENT_LOCK) Lock agentLock,
+                        @Named(BaragonAgentServiceModule.AGENT_LOCK_TIMEOUT_MS) long agentLockTimeoutMs) {
+    this.stateDatastore = stateDatastore;
+    this.configHelper = configHelper;
+    this.configuration = configuration;
+    this.agentLock = agentLock;
+    this.agentLockTimeoutMs = agentLockTimeoutMs;
+  }
+
+  @Override
+  public void stateChanged(CuratorFramework client, ConnectionState newState) {
+    if (newState.equals(ConnectionState.RECONNECTED)) {
+      reapplyConfigsWithRetry();
+    }
+  }
+
+  private void reapplyConfigsWithRetry() {
+    Callable<Void> callable = new Callable<Void>() {
+      public Void call() throws Exception {
+        if (agentLock.tryLock(agentLockTimeoutMs, TimeUnit.MILLISECONDS)) {
+          applyCurrentConfigs();
+          return null;
+        } else {
+          throw new ReapplyFailedException("Failed to acquire lock to reapply most current configs");
+        }
+      }
+    };
+
+    Retryer<Void> retryer = RetryerBuilder.<Void>newBuilder()
+      .retryIfException()
+      .withStopStrategy(StopStrategies.stopAfterAttempt(configuration.getMaxReapplyConfigAttempts()))
+      .withWaitStrategy(WaitStrategies.exponentialWait(1, TimeUnit.SECONDS))
+      .build();
+
+    try {
+      retryer.call(callable);
+    } catch (Exception e) {
+      // Shut down and exit, we are not in sync
+    }
+  }
+
+  public void applyCurrentConfigs() {
+    LOG.info("Loading current state of the world from zookeeper...");
+
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    final long now = System.currentTimeMillis();
+
+    final Collection<String> services = stateDatastore.getServices();
+    if (services.size() > 0) {
+      ExecutorService executorService = Executors.newFixedThreadPool(services.size());
+      List<Callable<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>>> todo = new ArrayList<>(services.size());
+
+      for (BaragonServiceState serviceState : stateDatastore.getGlobalState()) {
+        if (!(serviceState.getService().getLoadBalancerGroups() == null) && serviceState.getService().getLoadBalancerGroups().contains(configuration.getLoadBalancerConfiguration().getName())) {
+          todo.add(new BootstrapFileChecker(configHelper, serviceState, now));
+        }
+      }
+
+      LOG.info("Going to apply {} services...", todo.size());
+
+      try {
+        List<Future<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>>> applied = executorService.invokeAll(todo);
+        for (Future<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>> serviceFuture : applied) {
+          Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>> maybeToApply = serviceFuture.get();
+          if (maybeToApply.isPresent()) {
+            try {
+              configHelper.bootstrapApply(maybeToApply.get().getKey(), maybeToApply.get().getValue());
+            } catch (Exception e) {
+              LOG.error(String.format("Caught exception while applying %s during bootstrap", maybeToApply.get().getKey().getService().getServiceId()), e);
+            }
+          }
+        }
+        configHelper.checkAndReload();
+      } catch (Exception e) {
+        LOG.error(String.format("Caught exception while applying and parsing configs"), e);
+        if (configuration.isExitOnStartupError()) {
+          Throwables.propagate(e);
+        }
+      }
+
+      LOG.info("Applied {} services in {}ms", todo.size(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    } else {
+      LOG.info("No services were found to apply");
+    }
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/ResyncListener.java
@@ -19,6 +19,7 @@ import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
 import com.hubspot.baragon.agent.managed.LifecycleHelper;
 import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.exceptions.ReapplyFailedException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
@@ -92,6 +93,7 @@ public class ResyncListener implements ConnectionStateListener {
     }
   }
 
+  @SuppressFBWarnings("DM_EXIT")
   private void abort(Exception exception) {
     LOG.error("Caught exception while trying to resync, aborting", exception);
     flushLogs();
@@ -102,13 +104,11 @@ public class ResyncListener implements ConnectionStateListener {
         lifecycleHelper.shutdown();
       } catch (Exception e) {
         LOG.warn("While aborting server", e);
-      } finally {
-        System.exit(1);
       }
     } else {
       LOG.warn("Baragon Agent abort called before server has fully initialized!");
-      System.exit(1);
     }
+    System.exit(1);
   }
 
   private void flushLogs() {

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
@@ -1,0 +1,208 @@
+package com.hubspot.baragon.agent.managed;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.base.Optional;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.hubspot.baragon.agent.BaragonAgentServiceModule;
+import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
+import com.hubspot.baragon.agent.lbs.BootstrapFileChecker;
+import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
+import com.hubspot.baragon.agent.workers.AgentHeartbeatWorker;
+import com.hubspot.baragon.data.BaragonAuthDatastore;
+import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.data.BaragonWorkerDatastore;
+import com.hubspot.baragon.exceptions.AgentStartupException;
+import com.hubspot.baragon.models.BaragonAgentMetadata;
+import com.hubspot.baragon.models.BaragonAuthKey;
+import com.hubspot.baragon.models.BaragonConfigFile;
+import com.hubspot.baragon.models.BaragonServiceState;
+import com.hubspot.baragon.models.ServiceContext;
+import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpResponse;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LifecycleHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(LifecycleHelper.class);
+
+  private static final String SERVICE_CHECKIN_URL_FORMAT = "%s/checkin/%s/%s";
+
+  private final BaragonAuthDatastore authDatastore;
+  private final BaragonWorkerDatastore workerDatastore;
+  private final BaragonAgentConfiguration configuration;
+  private final BaragonAgentMetadata baragonAgentMetadata;
+  private final FilesystemConfigHelper configHelper;
+  private final BaragonStateDatastore stateDatastore;
+  private final HttpClient httpClient;
+  private final ScheduledExecutorService executorService;
+  private final LeaderLatch leaderLatch;
+
+  @Inject
+  public LifecycleHelper(BaragonWorkerDatastore workerDatastore,
+                         BaragonAuthDatastore authDatastore,
+                         BaragonAgentConfiguration configuration,
+                         BaragonAgentMetadata baragonAgentMetadata,
+                         FilesystemConfigHelper configHelper,
+                         BaragonStateDatastore stateDatastore,
+                         @Named(BaragonAgentServiceModule.BARAGON_AGENT_HTTP_CLIENT) HttpClient httpClient,
+                         @Named(BaragonAgentServiceModule.AGENT_SCHEDULED_EXECUTOR) ScheduledExecutorService executorService,
+                         @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch) {
+    this.workerDatastore = workerDatastore;
+    this.authDatastore = authDatastore;
+    this.configuration = configuration;
+    this.baragonAgentMetadata = baragonAgentMetadata;
+    this.configHelper = configHelper;
+    this.stateDatastore = stateDatastore;
+    this.httpClient = httpClient;
+    this.executorService = executorService;
+    this.leaderLatch = leaderLatch;
+
+  }
+
+  public void notifyServiceWithRetry(final String action) {
+    Callable<Void> callable = new Callable<Void>() {
+      public Void call() throws Exception {
+        notifyService(action);
+        return null;
+      }
+    };
+
+    Retryer<Void> retryer = RetryerBuilder.<Void>newBuilder()
+      .retryIfException()
+      .withStopStrategy(StopStrategies.stopAfterAttempt(configuration.getMaxNotifyServiceAttempts()))
+      .withWaitStrategy(WaitStrategies.exponentialWait(1, TimeUnit.SECONDS))
+      .build();
+
+    try {
+      retryer.call(callable);
+    } catch (Exception e) {
+      if (action.equals("startup") && !configuration.isExitOnStartupError()) {
+        LOG.error("Could not notify service of startup", e);
+      } else {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  public void notifyService(String action) throws AgentStartupException {
+    Collection<String> baseUris = workerDatastore.getBaseUris();
+    if (!baseUris.isEmpty()) {
+      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        .setUrl(String.format(SERVICE_CHECKIN_URL_FORMAT, baseUris.iterator().next(), configuration.getLoadBalancerConfiguration().getName(), action))
+        .setMethod(HttpRequest.Method.POST)
+        .setBody(baragonAgentMetadata);
+
+      Map<String, BaragonAuthKey> authKeys = authDatastore.getAuthKeyMap();
+      if (!authKeys.isEmpty()) {
+        requestBuilder.setQueryParam("authkey").to(authKeys.entrySet().iterator().next().getValue().getValue());
+      }
+
+      HttpRequest request = requestBuilder.build();
+      HttpResponse response = httpClient.execute(request);
+      LOG.info(String.format("Got %s response from BaragonService", response.getStatusCode()));
+      if (response.isError()) {
+        throw new AgentStartupException(String.format("Bad response received from BaragonService %s", response.getAsString()));
+      }
+    }
+  }
+
+  public void writeStateFileIfConfigured() throws IOException {
+    if (configuration.getStateFile().isPresent()) {
+      LOG.info("Writing state file...");
+      Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(configuration.getStateFile().get()), "UTF-8"));
+      try {
+        writer.write("RUNNING");
+      } finally {
+        writer.close();
+      }
+    }
+  }
+
+  public boolean removeStateFile() {
+    File stateFile = new File(configuration.getStateFile().get());
+    return (!stateFile.exists() || stateFile.delete());
+  }
+
+  public void applyCurrentConfigs() {
+    LOG.info("Loading current state of the world from zookeeper...");
+
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    final long now = System.currentTimeMillis();
+
+    final Collection<String> services = stateDatastore.getServices();
+    if (services.size() > 0) {
+      ExecutorService executorService = Executors.newFixedThreadPool(services.size());
+      List<Callable<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>>> todo = new ArrayList<>(services.size());
+
+      for (BaragonServiceState serviceState : stateDatastore.getGlobalState()) {
+        if (!(serviceState.getService().getLoadBalancerGroups() == null) && serviceState.getService().getLoadBalancerGroups().contains(configuration.getLoadBalancerConfiguration().getName())) {
+          todo.add(new BootstrapFileChecker(configHelper, serviceState, now));
+        }
+      }
+
+      LOG.info("Going to apply {} services...", todo.size());
+
+      try {
+        List<Future<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>>> applied = executorService.invokeAll(todo);
+        for (Future<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>> serviceFuture : applied) {
+          Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>> maybeToApply = serviceFuture.get();
+          if (maybeToApply.isPresent()) {
+            try {
+              configHelper.bootstrapApply(maybeToApply.get().getKey(), maybeToApply.get().getValue());
+            } catch (Exception e) {
+              LOG.error(String.format("Caught exception while applying %s during bootstrap", maybeToApply.get().getKey().getService().getServiceId()), e);
+            }
+          }
+        }
+        configHelper.checkAndReload();
+      } catch (Exception e) {
+        LOG.error(String.format("Caught exception while applying and parsing configs"), e);
+        if (configuration.isExitOnStartupError()) {
+          Throwables.propagate(e);
+        }
+      }
+
+      LOG.info("Applied {} services in {}ms", todo.size(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    } else {
+      LOG.info("No services were found to apply");
+    }
+  }
+
+  public void shutdown() throws Exception {
+    leaderLatch.close();
+    executorService.shutdown();
+    if (configuration.isDeregisterOnGracefulShutdown()) {
+      LOG.info("Notifying BaragonService of shutdown...");
+      notifyServiceWithRetry("shutdown");
+    }
+    if (configuration.getStateFile().isPresent()) {
+      removeStateFile();
+    }
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -81,7 +81,7 @@ public class AgentRequestManager {
         case DELETE:
           return delete(request, maybeOldService);
         case RELOAD:
-          return reload();
+          return reload(request);
         case REVERT:
           return revert(request, maybeOldService);
         default:
@@ -96,14 +96,16 @@ public class AgentRequestManager {
     }
   }
 
-  private Response reload() throws Exception {
+  private Response reload(BaragonRequest request) throws Exception {
     configHelper.checkAndReload();
+    mostRecentRequestId.set(request.getLoadBalancerRequestId());
     return Response.ok().build();
   }
 
   private Response delete(BaragonRequest request, Optional<BaragonService> maybeOldService) throws Exception {
     try {
       configHelper.delete(request.getLoadBalancerService(), maybeOldService);
+      mostRecentRequestId.set(request.getLoadBalancerRequestId());
       return Response.ok().build();
     } catch (Exception e) {
       return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();

--- a/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/ReapplyFailedException.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/ReapplyFailedException.java
@@ -1,0 +1,8 @@
+package com.hubspot.baragon.exceptions;
+
+public class ReapplyFailedException extends Exception {
+  public ReapplyFailedException(String message) {
+    super(message);
+  }
+}
+

--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -48,22 +48,6 @@ public class BaragonDataModule extends AbstractModule {
 
   @Singleton
   @Provides
-  public CuratorFramework provideCurator(ZooKeeperConfiguration config, BaragonConnectionStateListener connectionStateListener) {
-    CuratorFramework client = CuratorFrameworkFactory.newClient(
-        config.getQuorum(),
-        config.getSessionTimeoutMillis(),
-        config.getConnectTimeoutMillis(),
-        new ExponentialBackoffRetry(config.getRetryBaseSleepTimeMilliseconds(), config.getRetryMaxTries()));
-
-    client.getConnectionStateListenable().addListener(connectionStateListener);
-
-    client.start();
-
-    return client.usingNamespace(config.getZkNamespace());
-  }
-
-  @Singleton
-  @Provides
   public ObjectMapper provideObjectMapper() {
     final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -12,15 +12,11 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.hubspot.baragon.config.AuthConfiguration;
-import com.hubspot.baragon.config.ZooKeeperConfiguration;
 import com.hubspot.baragon.data.BaragonAuthDatastore;
-import com.hubspot.baragon.data.BaragonConnectionStateListener;
 import com.hubspot.baragon.models.BaragonAuthKey;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 
 public class BaragonDataModule extends AbstractModule {
   public static final String BARAGON_AGENT_REQUEST_URI_FORMAT = "baragon.agent.request.uri.format";

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -30,6 +30,7 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
 
   public static final String LOAD_BALANCER_GROUPS_FORMAT = "/load-balancer";
   public static final String LOAD_BALANCER_GROUP_FORMAT = LOAD_BALANCER_GROUPS_FORMAT + "/%s";
+  public static final String LOAD_BALANCER_GROUP_LAST_REQUEST_FORMAT = LOAD_BALANCER_GROUP_FORMAT + "/lastRequest";
   public static final String LOAD_BALANCER_GROUP_HOSTS_FORMAT = LOAD_BALANCER_GROUP_FORMAT + "/hosts";
   public static final String LOAD_BALANCER_GROUP_HOST_FORMAT = LOAD_BALANCER_GROUP_HOSTS_FORMAT + "/%s";
 
@@ -195,5 +196,13 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     }
 
     return decodedPaths;
+  }
+
+  public Optional<String> getLastRequestForGroup(String loadBalancerGroup) {
+    return readFromZk(String.format(LOAD_BALANCER_GROUP_LAST_REQUEST_FORMAT, loadBalancerGroup), String.class);
+  }
+
+  public void setLastRequestId(String loadBalancerGroup, String requestId) {
+    writeToZk(String.format(LOAD_BALANCER_GROUP_LAST_REQUEST_FORMAT, loadBalancerGroup), requestId);
   }
 }

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -133,6 +133,10 @@
       <artifactId>async-http-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jukito</groupId>
       <artifactId>jukito</artifactId>
       <scope>test</scope>

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -259,6 +259,13 @@ public class RequestManager {
         LOG.debug(String.format("No updates to commit for request action %s", action));
         break;
     }
+    updateLastRequestForGroups(request);
+  }
+
+  private void updateLastRequestForGroups(BaragonRequest request) {
+    for (String loadBalancerGroup : request.getLoadBalancerService().getLoadBalancerGroups()) {
+      loadBalancerDatastore.setLastRequestId(loadBalancerGroup, request.getLoadBalancerRequestId());
+    }
   }
 
   private Optional<BaragonService> getOriginalService(BaragonRequest request) {


### PR DESCRIPTION
Still a bit more to do with this, but this is a wip for continuing to be in sync after losing zk connection. I still am going to implement some sort of checkpoint (ie last request id applied for a group) to have a quicker check if the agent is still in sync. Whole flow would go like:

- Lose Connection
- Regain Connection
- If last request id is the same as in zk
  - continue processing requests, we are ok
- else if last request id is different
  - grab the agent request lock and reapply the world from state datastore
  - if we error here or cannot reapply the world, abort because we are serving traffic from out of sync configs.

/cc @tpetr 