### PR TITLE
Max number of requests to keep/return to ui per service

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
@@ -19,6 +19,6 @@ public class BaragonRequestKey implements Comparable<BaragonRequestKey> {
 
   @Override
   public int compareTo(BaragonRequestKey o) {
-    return updatedAt >= o.updatedAt ? -1 : 1;
+    return Long.compare(updatedAt, o.updatedAt);
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
@@ -4,8 +4,8 @@ public class BaragonRequestKey implements Comparable<BaragonRequestKey> {
   private final String requestId;
   private final long updatedAt;
 
-  public BaragonRequestKey(String reqeustId, long updatedAt) {
-    this.requestId = reqeustId;
+  public BaragonRequestKey(String requestId, long updatedAt) {
+    this.requestId = requestId;
     this.updatedAt = updatedAt;
   }
 

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestKey.java
@@ -1,0 +1,24 @@
+package com.hubspot.baragon.models;
+
+public class BaragonRequestKey implements Comparable<BaragonRequestKey> {
+  private final String requestId;
+  private final long updatedAt;
+
+  public BaragonRequestKey(String reqeustId, long updatedAt) {
+    this.requestId = reqeustId;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
+  public int compareTo(BaragonRequestKey o) {
+    return updatedAt >= o.updatedAt ? -1 : 1;
+  }
+}

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.data;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,14 +43,16 @@ public class BaragonResponseHistoryDatastore extends AbstractDataStore {
     return readFromZk(String.format(RESPONSE_HISTORY_FORMAT, serviceId, requestId), BaragonResponse.class);
   }
 
-  public List<BaragonResponse> getResponsesForService(String serviceId) {
+  public List<BaragonResponse> getResponsesForService(String serviceId, int limit) {
     final List<String> nodes = getChildren(String.format(RESPONSE_HISTORIES_FOR_SERVICE_FORMAT, serviceId));
-    final List<BaragonResponse> responses = Lists.newArrayListWithCapacity(nodes.size());
-    for (String node : nodes) {
+    final List<BaragonResponse> responses = Lists.newArrayListWithCapacity(Math.min(nodes.size(), limit));
+    Iterator<String> nodeIterator = nodes.iterator();
+    for (int i = 0; nodeIterator.hasNext() && i < limit; i++) {
+      String requestId = nodeIterator.next();
       try {
-        responses.addAll(readFromZk(String.format(RESPONSE_HISTORY_FORMAT, serviceId, node), BaragonResponse.class).asSet());
+        responses.addAll(readFromZk(String.format(RESPONSE_HISTORY_FORMAT, serviceId, requestId), BaragonResponse.class).asSet());
       } catch (Exception e) {
-        LOG.error(String.format("Could not fetch info for group %s due to error %s", node, e));
+        LOG.error(String.format("Could not fetch info for group %s due to error %s", requestId, e));
       }
     }
     return responses;

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
@@ -47,7 +47,7 @@ public class BaragonResponseHistoryDatastore extends AbstractDataStore {
   public List<BaragonResponse> getResponsesForService(String serviceId, int limit) {
     final List<String> nodes = getChildren(String.format(RESPONSE_HISTORIES_FOR_SERVICE_FORMAT, serviceId));
     final List<BaragonResponse> responses = Lists.newArrayListWithCapacity(Math.min(nodes.size(), limit));
-    for (String requestId : nodes.subList(0, limit)) {
+    for (String requestId : nodes.subList(0, Math.min(nodes.size(), limit))) {
       try {
         responses.addAll(readFromZk(String.format(RESPONSE_HISTORY_FORMAT, serviceId, requestId), BaragonResponse.class).asSet());
       } catch (Exception e) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonResponseHistoryDatastore.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -46,9 +47,7 @@ public class BaragonResponseHistoryDatastore extends AbstractDataStore {
   public List<BaragonResponse> getResponsesForService(String serviceId, int limit) {
     final List<String> nodes = getChildren(String.format(RESPONSE_HISTORIES_FOR_SERVICE_FORMAT, serviceId));
     final List<BaragonResponse> responses = Lists.newArrayListWithCapacity(Math.min(nodes.size(), limit));
-    Iterator<String> nodeIterator = nodes.iterator();
-    for (int i = 0; nodeIterator.hasNext() && i < limit; i++) {
-      String requestId = nodeIterator.next();
+    for (String requestId : nodes.subList(0, limit)) {
       try {
         responses.addAll(readFromZk(String.format(RESPONSE_HISTORY_FORMAT, serviceId, requestId), BaragonResponse.class).asSet());
       } catch (Exception e) {

--- a/BaragonService/src/main/docker/baragon.yaml
+++ b/BaragonService/src/main/docker/baragon.yaml
@@ -12,6 +12,7 @@ history:
   purgeOldRequestsAfterDays: 1
   purgeWhenDateNotFound: true
   purgeEveryHours: 1
+  maxRequestsPerService: 5
 
 zookeeper:
   quorum: localhost:2181

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/HistoryConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/HistoryConfiguration.java
@@ -30,6 +30,9 @@ public class HistoryConfiguration {
   @JsonProperty("maxRequestsPerService")
   int maxRequestsPerService = 1000;
 
+  @JsonProperty("maxResponsesToFetch")
+  int maxResponsesToFetch = 1000;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -84,5 +87,13 @@ public class HistoryConfiguration {
 
   public void setMaxRequestsPerService(int maxRequestsPerService) {
     this.maxRequestsPerService = maxRequestsPerService;
+  }
+
+  public int getMaxResponsesToFetch() {
+    return maxResponsesToFetch;
+  }
+
+  public void setMaxResponsesToFetch(int maxResponsesToFetch) {
+    this.maxResponsesToFetch = maxResponsesToFetch;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/HistoryConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/HistoryConfiguration.java
@@ -27,6 +27,9 @@ public class HistoryConfiguration {
   @Min(1)
   int purgeEveryHours = 24;
 
+  @JsonProperty("maxRequestsPerService")
+  int maxRequestsPerService = 1000;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -73,5 +76,13 @@ public class HistoryConfiguration {
 
   public void setPurgeEveryHours(int purgeEveryHours) {
     this.purgeEveryHours = purgeEveryHours;
+  }
+
+  public int getMaxRequestsPerService() {
+    return maxRequestsPerService;
+  }
+
+  public void setMaxRequestsPerService(int maxRequestsPerService) {
+    this.maxRequestsPerService = maxRequestsPerService;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -26,6 +26,7 @@ import com.hubspot.baragon.models.InternalRequestStates;
 import com.hubspot.baragon.models.InternalStatesMap;
 import com.hubspot.baragon.models.QueuedRequestId;
 import com.hubspot.baragon.models.RequestAction;
+import com.hubspot.baragon.service.config.BaragonConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,16 +38,21 @@ public class RequestManager {
   private final BaragonStateDatastore stateDatastore;
   private final BaragonAgentResponseDatastore agentResponseDatastore;
   private final BaragonResponseHistoryDatastore responseHistoryDatastore;
+  private final BaragonConfiguration configuration;
 
   @Inject
-  public RequestManager(BaragonRequestDatastore requestDatastore, BaragonLoadBalancerDatastore loadBalancerDatastore,
-                        BaragonStateDatastore stateDatastore, BaragonAgentResponseDatastore agentResponseDatastore,
-                        BaragonResponseHistoryDatastore responseHistoryDatastore) {
+  public RequestManager(BaragonRequestDatastore requestDatastore,
+                        BaragonLoadBalancerDatastore loadBalancerDatastore,
+                        BaragonStateDatastore stateDatastore,
+                        BaragonAgentResponseDatastore agentResponseDatastore,
+                        BaragonResponseHistoryDatastore responseHistoryDatastore,
+                        BaragonConfiguration configuration) {
     this.requestDatastore = requestDatastore;
     this.loadBalancerDatastore = loadBalancerDatastore;
     this.stateDatastore = stateDatastore;
     this.agentResponseDatastore = agentResponseDatastore;
     this.responseHistoryDatastore = responseHistoryDatastore;
+    this.configuration = configuration;
   }
 
   public Optional<BaragonRequest> getRequest(String requestId) {
@@ -84,7 +90,7 @@ public class RequestManager {
         }
       }
     }
-    responses.addAll(responseHistoryDatastore.getResponsesForService(serviceId));
+    responses.addAll(responseHistoryDatastore.getResponsesForService(serviceId, configuration.getHistoryConfiguration().getMaxResponsesToFetch()));
     return responses;
   }
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
@@ -181,7 +181,7 @@ public class RequestPurgingWorker implements Runnable {
     }
   }
 
-  class ValueComparator implements Comparator<String> {
+  public static class ValueComparator implements Comparator<String> {
 
     Map<String, Long> base;
     public ValueComparator(Map<String, Long> base) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.hubspot.baragon.data.BaragonAgentResponseDatastore;
 import com.hubspot.baragon.data.BaragonRequestDatastore;
@@ -180,9 +181,8 @@ public class RequestPurgingWorker implements Runnable {
     }
     sortedTimestampMap.putAll(timestampMap);
     int numToDelete = sortedTimestampMap.size() - configuration.getHistoryConfiguration().getMaxRequestsPerService();
-    Iterator<String> iterator = sortedTimestampMap.keySet().iterator();
-    for (int i = 0; iterator.hasNext() && i < numToDelete; i++) {
-      responseHistoryDatastore.deleteResponse(serviceId, iterator.next());
+    for (String requestId : Iterables.limit(sortedTimestampMap.keySet(), numToDelete)) {
+      responseHistoryDatastore.deleteResponse(serviceId, requestId);
     }
   }
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
@@ -1,5 +1,6 @@
 package com.hubspot.baragon.service.worker;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -181,7 +182,7 @@ public class RequestPurgingWorker implements Runnable {
     }
   }
 
-  public static class ValueComparator implements Comparator<String> {
+  public static class ValueComparator implements Comparator<String>, Serializable {
 
     Map<String, Long> base;
     public ValueComparator(Map<String, Long> base) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/RequestPurgingWorker.java
@@ -181,8 +181,7 @@ public class RequestPurgingWorker implements Runnable {
       }
     }
     Collections.sort(requestKeyList);
-    int numToDelete = requestKeyList.size() - configuration.getHistoryConfiguration().getMaxRequestsPerService();
-    for (BaragonRequestKey requestKey : requestKeyList.subList(0, numToDelete)) {
+    for (BaragonRequestKey requestKey : requestKeyList.subList(configuration.getHistoryConfiguration().getMaxRequestsPerService(), requestKeyList.size())) {
       responseHistoryDatastore.deleteResponse(serviceId, requestKey.getRequestId());
     }
   }


### PR DESCRIPTION
Two steps for making sure we don't make disastrous zk calls or try and load too many requests/responses at once:

- [x] Enforce a max number of requests to keep per service (ie. we probably don't need 40k responses, even if there are all in the last 60 days). This is configurable
- [x] Enforce a limit on the number of historical responses we fetch at once

@tpetr 