### PR TITLE
noVerify/noReload options

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -103,7 +103,7 @@ public class AgentRequestManager {
 
   private Response delete(BaragonRequest request, Optional<BaragonService> maybeOldService) throws Exception {
     try {
-      configHelper.delete(request.getLoadBalancerService(), maybeOldService);
+      configHelper.delete(request.getLoadBalancerService(), maybeOldService, request.isNoReload(), request.isNoValidate());
       return Response.ok().build();
     } catch (Exception e) {
       return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
@@ -114,7 +114,7 @@ public class AgentRequestManager {
     final ServiceContext update = getApplyContext(request);
     triggerTesting();
     try {
-      configHelper.apply(update, maybeOldService, true);
+      configHelper.apply(update, maybeOldService, true, request.isNoReload(), request.isNoValidate());
     } catch (Exception e) {
       return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
@@ -134,7 +134,7 @@ public class AgentRequestManager {
 
     LOG.info(String.format("Reverting to %s", update));
     try {
-      configHelper.apply(update, Optional.<BaragonService>absent(), false);
+      configHelper.apply(update, Optional.<BaragonService>absent(), false, request.isNoReload(), request.isNoValidate());
     } catch (MissingTemplateException e) {
       if (serviceDidNotPreviouslyExist(maybeOldService)) {
         return Response.ok().build();

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -36,6 +36,12 @@ public class BaragonRequest {
 
   private final List<UpstreamInfo> replaceUpstreams;
 
+  @NotNull
+  private final boolean noValidate;
+
+  @NotNull
+  private final boolean noReload;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
@@ -43,7 +49,9 @@ public class BaragonRequest {
                         @JsonProperty("removeUpstreams") List<UpstreamInfo> removeUpstreams,
                         @JsonProperty("replaceUpstreams") List<UpstreamInfo> replaceUpstreams,
                         @JsonProperty("replaceServiceId") Optional<String> replaceServiceId,
-                        @JsonProperty("action") Optional<RequestAction> action) {
+                        @JsonProperty("action") Optional<RequestAction> action,
+                        @JsonProperty("noValidate") boolean noValidate,
+                        @JsonProperty("noReload") boolean noReload) {
     this.loadBalancerRequestId = loadBalancerRequestId;
     this.loadBalancerService = loadBalancerService;
     this.addUpstreams = addRequestId(addUpstreams, loadBalancerRequestId);
@@ -51,14 +59,21 @@ public class BaragonRequest {
     this.replaceServiceId = replaceServiceId;
     this.action = action;
     this.replaceUpstreams = Objects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
+    this.noValidate = Objects.firstNonNull(noValidate, false);
+    this.noReload = noReload;
+
+  }
+
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE));
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false);
   }
 
   public String getLoadBalancerRequestId() {
@@ -110,6 +125,14 @@ public class BaragonRequest {
     }
   }
 
+  public boolean isNoValidate() {
+    return noValidate;
+  }
+
+  public boolean isNoReload() {
+    return noReload;
+  }
+
   @Override
   public String toString() {
     return "BaragonRequest [" +
@@ -119,6 +142,8 @@ public class BaragonRequest {
         ", removeUpstreams=" + removeUpstreams +
         ", replaceServiceId=" + replaceServiceId +
         ", action=" + action +
+        ", noValidate=" + noValidate +
+        ", noReload=" + noReload +
         ']';
   }
 
@@ -151,6 +176,12 @@ public class BaragonRequest {
     if (!action.equals(request.getAction())) {
       return false;
     }
+    if (!noValidate == request.noValidate) {
+      return false;
+    }
+    if (!noReload == request.noReload) {
+      return false;
+    }
 
     return true;
   }
@@ -163,6 +194,8 @@ public class BaragonRequest {
     result = 31 * result + removeUpstreams.hashCode();
     result = 31 * result + replaceServiceId.hashCode();
     result = 31 * result + action.hashCode();
+    result = 31 * result + (noValidate ? 1 : 0);
+    result = 31 * result + (noReload ? 1 : 0);
     return result;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -197,6 +197,10 @@ public class RequestManager {
       }
     }
 
+    if (request.isNoReload() && request.getAction().isPresent() && request.getAction().get().equals(RequestAction.RELOAD)) {
+      throw new InvalidRequestActionException("You can not specify 'noReload' on a request with action 'RELOAD'");
+    }
+
     if (!request.getReplaceUpstreams().isEmpty() && (!request.getAddUpstreams().isEmpty() || !request.getRemoveUpstreams().isEmpty())) {
       throw new InvalidUpstreamsException("If overrideUpstreams is specified, addUpstreams and removeUpstreams mustbe empty");
     }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ServiceManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ServiceManager.java
@@ -44,12 +44,12 @@ public class ServiceManager {
     }
   }
 
-  public BaragonResponse enqueueReloadServiceConfigs(String serviceId) {
+  public BaragonResponse enqueueReloadServiceConfigs(String serviceId, boolean noValidate) {
     String requestId = String.format("%s-%s-%s", serviceId, System.currentTimeMillis(), "RELOAD");
     Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
     if (maybeService.isPresent()) {
       try {
-        return requestManager.enqueueRequest(buildReloadRequest(maybeService.get(), requestId));
+        return requestManager.enqueueRequest(buildReloadRequest(maybeService.get(), requestId, noValidate));
       } catch (Exception e) {
         return BaragonResponse.failure(requestId, e.getMessage());
       }
@@ -58,12 +58,12 @@ public class ServiceManager {
     }
   }
 
-  public BaragonResponse enqueueRemoveService(String serviceId) {
+  public BaragonResponse enqueueRemoveService(String serviceId, boolean noValidate, boolean noReload) {
     String requestId = String.format("%s-%s-%s", serviceId, System.currentTimeMillis(), "DELETE");
     Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
     if (maybeService.isPresent()) {
       try {
-        return requestManager.enqueueRequest(buildRemoveRequest(maybeService.get(), requestId));
+        return requestManager.enqueueRequest(buildRemoveRequest(maybeService.get(), requestId, noValidate, noReload));
       } catch (Exception e) {
         return BaragonResponse.failure(requestId, e.getMessage());
       }
@@ -72,15 +72,15 @@ public class ServiceManager {
     }
   }
 
-  private BaragonRequest buildRemoveRequest(BaragonService service, String requestId) throws Exception {
+  private BaragonRequest buildRemoveRequest(BaragonService service, String requestId, boolean noValidate, boolean noReload) throws Exception {
     List<UpstreamInfo> empty = Collections.emptyList();
     List<UpstreamInfo> remove;
     remove =  new ArrayList<>(stateDatastore.getUpstreamsMap(service.getServiceId()).values());
-    return new BaragonRequest(requestId, service, empty, remove, empty, Optional.<String>absent(), Optional.of(RequestAction.DELETE));
+    return new BaragonRequest(requestId, service, empty, remove, empty, Optional.<String>absent(), Optional.of(RequestAction.DELETE), noValidate, noReload);
   }
 
-  private BaragonRequest buildReloadRequest(BaragonService service, String requestId) {
+  private BaragonRequest buildReloadRequest(BaragonService service, String requestId, boolean noValidate) {
     List<UpstreamInfo> empty = Collections.emptyList();
-    return new BaragonRequest(requestId, service, empty, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD));
+    return new BaragonRequest(requestId, service, empty, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD), noValidate, false);
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/StateResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/StateResource.java
@@ -3,11 +3,13 @@ package com.hubspot.baragon.service.resources;
 import java.util.Collection;
 
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Optional;
@@ -43,13 +45,13 @@ public class StateResource {
 
   @POST
   @Path("/{serviceId}/reload")
-  public BaragonResponse reloadConfigs(@PathParam("serviceId") String serviceId) {
-    return serviceManager.enqueueReloadServiceConfigs(serviceId);
+  public BaragonResponse reloadConfigs(@PathParam("serviceId") String serviceId, @DefaultValue("false") @QueryParam("noValidate") boolean noValidate) {
+    return serviceManager.enqueueReloadServiceConfigs(serviceId, noValidate);
   }
 
   @DELETE
   @Path("/{serviceId}")
-  public BaragonResponse removeService(@PathParam("serviceId") String serviceId) {
-    return serviceManager.enqueueRemoveService(serviceId);
+  public BaragonResponse removeService(@PathParam("serviceId") String serviceId, @DefaultValue("false") @QueryParam("noValidate") boolean noValidate, @DefaultValue("false") @QueryParam("noReload") boolean noReload) {
+    return serviceManager.enqueueRemoveService(serviceId, noValidate, noReload);
   }
 }

--- a/BaragonUI/app/models/Service.coffee
+++ b/BaragonUI/app/models/Service.coffee
@@ -13,12 +13,13 @@ class Service extends Model
     removeUpstreamsSuccessTemplate: require '../templates/vex/removeUpstreamsSuccess'
 
     noReloadNoValidateInput: """
-            <input name="noValidate" type="checkbox" >Don't validate configs for this request</input>
-            <input name="noReload" type="checkbox" >Don't reload configs for this request</input>
+            <input name="validate" type="checkbox" checked> Validate new configuration after applying changes</input>
+            <br>
+            <input name="reload" type="checkbox" checked> Reload configuration after applying changes</input>
         """
 
     noValidateInput: """
-            <input name="noValidate" type="checkbox" >Don't validate configs for this request</input>
+            <input name="validate" type="checkbox" checked> Validate configuration before reloading</input>
         """
 
     initialize: ({ @serviceId }) ->
@@ -114,7 +115,9 @@ class Service extends Model
             ]
             callback: (data) =>
                 return if data is false
-                @delete(data.noValidate, data.noReload).done callback
+                noValidate = (!data.validate or data.validate != 'on')
+                noReload = (!data.reload or data.reload != 'on')
+                @delete(noValidate, noReload).done callback
 
     promptDeleteSuccess: (callback) =>
         vex.dialog.confirm
@@ -139,7 +142,8 @@ class Service extends Model
             ]
             callback: (data) =>
                 return if data is false
-                @reload(data.noValidate).done callback
+                noValidate = (!data.validate or data.validate != 'on')
+                @reload(noValidate).done callback
 
     promptReloadConfigsSuccess: (callback) =>
         vex.dialog.confirm
@@ -164,7 +168,9 @@ class Service extends Model
             ]
             callback: (data) =>
                 return if data is false
-                @undo(data.noValidate, data.noReload).done callback
+                noValidate = (!data.validate or data.validate != 'on')
+                noReload = (!data.reload or data.reload != 'on')
+                @undo(noValidate, noReload).done callback
 
     promptRemoveUpstreamsSuccess: (callback) =>
         vex.dialog.confirm
@@ -189,6 +195,8 @@ class Service extends Model
             ]
             callback: (data) =>
                 return if data is false
-                @remove(upstream, data.noValidate, data.noReload).done callback
+                noValidate = (!data.validate or data.validate != 'on')
+                noReload = (!data.reload or data.reload != 'on')
+                @remove(upstream, noValidate, noReload).done callback
 
 module.exports = Service


### PR DESCRIPTION
This will be useful especially when cleaning up multiple bad upstreams where the config check for removing the first would still fail. Added options for both ignoring reload and validation

/cc @tpetr 