### PR TITLE
save failed configs for later inspection

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -90,6 +90,9 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("configCheckIntervalSecs")
   private int configCheckIntervalSecs = 60;
 
+  @JsonProperty("saveFailedConfigs")
+  private boolean saveFailedConfigs = false;
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -236,5 +239,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setConfigCheckIntervalSecs(int configCheckIntervalSecs) {
     this.configCheckIntervalSecs = configCheckIntervalSecs;
+  }
+
+  public boolean isSaveFailedConfigs() {
+    return saveFailedConfigs;
+  }
+
+  public void setSaveFailedConfigs(boolean saveFailedConfigs) {
+    this.saveFailedConfigs = saveFailedConfigs;
   }
 }


### PR DESCRIPTION
Sometimes it is hard to debug invalid configs since we immediately delete them when a request fails. This will (optionally) save the invalid config with a .failed extension so we can look at it later