### PR TITLE
Add Mesos dependencies to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,17 @@ MAINTAINER HubSpot <platform-infrastructure-groups@hubspot.com>
 # Used to build hubspot/baragonagentbase image
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y python-setuptools nginx sed && \
+    apt-get install -y python-setuptools nginx sed \
+      libapr1-dev libsasl2-dev libcurl4-nss-dev libsvn-dev && \
     easy_install supervisor && \
     mkdir -p /etc/nginx/conf.d/custom && \
     mkdir -p /etc/nginx/conf.d/proxy && \
-    mkdir -p /etc/nginx/conf.d/upstreams
+    mkdir -p /etc/nginx/conf.d/upstreams && \
+    apt-get clean && \
+      rm -rf /var/cache/apt/* && \
+      rm -rf /var/lib/apt/lists/* && \
+      rm -rf /tmp/* && \
+      rm -rf /var/tmp/*
 
 COPY docker/supervisor /etc/supervisor
 COPY docker/nginx/conf.d /etc/nginx/conf.d


### PR DESCRIPTION
This allows you to easily run Baragon agents on a Mesos cluster. Also
removes the `apt-get upgrade -y` line since it's against Docker best
practices and increases the time needed to build the image.