### PR TITLE
enqueue requests in a transaction

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonRequestDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonRequestDatastore.java
@@ -114,8 +114,8 @@ public class BaragonRequestDatastore extends AbstractDataStore {
         createNode(REQUEST_QUEUE_FORMAT);
       }
 
-      byte [] requestBytes = objectMapper.writeValueAsBytes(request);
-      byte [] stateBytes = objectMapper.writeValueAsBytes(state);
+      byte[] requestBytes = objectMapper.writeValueAsBytes(request);
+      byte[] stateBytes = objectMapper.writeValueAsBytes(state);
 
       Collection<CuratorTransactionResult> results = curatorFramework.inTransaction()
           .create().forPath(requestPath, requestBytes).and()

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -79,15 +79,11 @@ public class RequestManager {
     requestDatastore.removeQueuedRequest(queuedRequestId);
   }
 
-  public void reenqueueStuckPendingRequests() {
+  public void failStuckPendingRequests() {
     for (String requestId : requestDatastore.getAllRequestIds()) {
       Optional<InternalRequestStates> maybeState = requestDatastore.getRequestState(requestId);
       if (!maybeState.isPresent() || (maybeState.get().equals(InternalRequestStates.PENDING) && !hasQueuedRequest(requestId))) {
-        Optional<BaragonRequest> maybeRequest = requestDatastore.getRequest(requestId);
-        if (maybeRequest.isPresent()) {
-          QueuedRequestId queuedRequestId = requestDatastore.enqueueRequest(maybeRequest.get());
-          requestDatastore.setRequestMessage(maybeRequest.get().getLoadBalancerRequestId(), String.format("Queued as %s", queuedRequestId));
-        }
+        setRequestState(requestId, InternalRequestStates.FAILED_REVERTED);
       }
     }
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -84,6 +84,7 @@ public class RequestManager {
       Optional<InternalRequestStates> maybeState = requestDatastore.getRequestState(requestId);
       if (!maybeState.isPresent() || (maybeState.get().equals(InternalRequestStates.PENDING) && !hasQueuedRequest(requestId))) {
         setRequestState(requestId, InternalRequestStates.FAILED_REVERTED);
+        setRequestMessage(requestId, "Request failed due to being stuck in PENDING state");
       }
     }
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -215,10 +215,7 @@ public class RequestManager {
       throw new InvalidRequestActionException("The REVERT action may only be used internally by Baragon, you may specify UPDATE, DELETE, RELOAD, or leave the action blank(UPDATE)");
     }
 
-    requestDatastore.addRequest(request);
-    requestDatastore.setRequestState(request.getLoadBalancerRequestId(), InternalRequestStates.PENDING);
-
-    final QueuedRequestId queuedRequestId = requestDatastore.enqueueRequest(request);
+    final QueuedRequestId queuedRequestId = requestDatastore.enqueueRequest(request, InternalRequestStates.PENDING);
 
     requestDatastore.setRequestMessage(request.getLoadBalancerRequestId(), String.format("Queued as %s", queuedRequestId));
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -79,25 +79,6 @@ public class RequestManager {
     requestDatastore.removeQueuedRequest(queuedRequestId);
   }
 
-  public void failStuckPendingRequests() {
-    for (String requestId : requestDatastore.getAllRequestIds()) {
-      Optional<InternalRequestStates> maybeState = requestDatastore.getRequestState(requestId);
-      if (!maybeState.isPresent() || (maybeState.get().equals(InternalRequestStates.PENDING) && !hasQueuedRequest(requestId))) {
-        setRequestState(requestId, InternalRequestStates.FAILED_REVERTED);
-        setRequestMessage(requestId, "Request failed due to being stuck in PENDING state");
-      }
-    }
-  }
-
-  private boolean hasQueuedRequest(String requestId) {
-    for (QueuedRequestId queuedRequestId : getQueuedRequestIds()) {
-      if (queuedRequestId.getRequestId().equals(requestId)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public List<BaragonResponse> getResponsesForService(String serviceId) {
     List<BaragonResponse> responses = new ArrayList<>();
     for (String requestId : requestDatastore.getAllRequestIds()) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -189,8 +189,6 @@ public class BaragonRequestWorker implements Runnable {
           }
         }
       }
-
-      requestManager.failStuckPendingRequests();
     } catch (Exception e) {
       LOG.warn("Caught exception", e);
     }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -175,8 +175,6 @@ public class BaragonRequestWorker implements Runnable {
     workerLastStartAt.set(System.currentTimeMillis());
 
     try {
-      requestManager.reenqueueStuckPendingRequests();
-
       final List<QueuedRequestId> queuedRequestIds = requestManager.getQueuedRequestIds();
 
       if (!queuedRequestIds.isEmpty()) {
@@ -191,6 +189,8 @@ public class BaragonRequestWorker implements Runnable {
           }
         }
       }
+
+      requestManager.failStuckPendingRequests();
     } catch (Exception e) {
       LOG.warn("Caught exception", e);
     }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -175,6 +175,7 @@ public class BaragonRequestWorker implements Runnable {
     workerLastStartAt.set(System.currentTimeMillis());
 
     try {
+      requestManager.reenqueueStuckPendingRequests();
 
       final List<QueuedRequestId> queuedRequestIds = requestManager.getQueuedRequestIds();
 


### PR DESCRIPTION
We saw that when zk connection was lost during the enqueue, with just the right timing we could write request data without enqueuing it. So the response will be present, but always in a waiting status. This will do those steps in a transaction so we don't run into any weird state