### PR TITLE
Make /state endpoint recompute global state

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.PathAndBytesable;
 import org.apache.zookeeper.CreateMode;
@@ -13,7 +14,6 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -98,7 +98,7 @@ public abstract class AbstractDataStore {
     final long start = System.currentTimeMillis();
 
     try {
-      final byte[] serializedInfo = objectMapper.writeValueAsBytes(data);
+      final byte[] serializedInfo = serialize(data);
 
       final PathAndBytesable<?> builder;
 
@@ -115,6 +115,14 @@ public abstract class AbstractDataStore {
     }
   }
 
+  protected <T> byte[] serialize(T data) {
+    try {
+      return objectMapper.writeValueAsBytes(data);
+    } catch (JsonProcessingException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
   protected <T> Optional<T> readFromZk(final String path, final Class<T> klass) {
     final long start = System.currentTimeMillis();
 
@@ -124,19 +132,6 @@ public abstract class AbstractDataStore {
       public T apply(byte[] data) {
         log(OperationType.READ, Optional.<Integer>absent(), Optional.of(data.length), start, path);
         return deserialize(data, klass);
-      }
-    });
-  }
-
-  protected <T> Optional<T> readFromZk(final String path, final TypeReference<T> typeReference) {
-    final long start = System.currentTimeMillis();
-
-    return readFromZk(path).transform(new Function<byte[], T>() {
-
-      @Override
-      public T apply(byte[] data) {
-        log(OperationType.READ, Optional.<Integer>absent(), Optional.of(data.length), start, path);
-        return deserialize(data, typeReference);
       }
     });
   }
@@ -159,45 +154,12 @@ public abstract class AbstractDataStore {
     }
   }
 
-  protected <T> T deserialize(byte[] data, TypeReference<T> typeReference) {
-    try {
-      return objectMapper.readValue(data, typeReference);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  protected String createNode(String path) {
-    final long start = System.currentTimeMillis();
-
-    try {
-      final String result = curatorFramework.create().creatingParentsIfNeeded().forPath(path);
-      log(OperationType.WRITE, Optional.<Integer>absent(), Optional.<Integer>absent(), start, path);
-      return result;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
   protected String createPersistentSequentialNode(String path) {
     final long start = System.currentTimeMillis();
 
     try {
       final String result = curatorFramework.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath(path);
       log(OperationType.WRITE, Optional.<Integer>absent(), Optional.<Integer>absent(), start, path);
-      return result;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  protected <T> String createPersistentSequentialNode(String path, T value) {
-    final long start = System.currentTimeMillis();
-
-    try {
-      final byte[] serializedValue = objectMapper.writeValueAsBytes(value);
-      final String result = curatorFramework.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath(path, serializedValue);
-      log(OperationType.WRITE, Optional.<Integer>absent(), Optional.of(serializedValue.length), start, path);
       return result;
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
@@ -154,6 +154,18 @@ public abstract class AbstractDataStore {
     }
   }
 
+  protected String createNode(String path) {
+    final long start = System.currentTimeMillis();
+
+    try {
+      final String result = curatorFramework.create().creatingParentsIfNeeded().forPath(path);
+      log(OperationType.WRITE, Optional.<Integer>absent(), Optional.<Integer>absent(), start, path);
+      return result;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
   protected String createPersistentSequentialNode(String path) {
     final long start = System.currentTimeMillis();
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
@@ -134,11 +133,18 @@ public class BaragonStateDatastore extends AbstractDataStore {
 
   @Timed
   public Collection<BaragonServiceState> getGlobalState() {
-    return deserialize(getGlobalStateAsBytes(), BARAGON_SERVICE_STATE_COLLECTION);
+    try {
+      LOG.info("Starting to compute all service states");
+      return computeAllServiceStates();
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    } finally {
+      LOG.info("Finished computing all service states");
+    }
   }
 
   public byte[] getGlobalStateAsBytes() {
-    return readFromZk(SERVICES_FORMAT).or("[]".getBytes(Charsets.UTF_8));
+    return serialize(getGlobalState());
   }
 
   @Timed


### PR DESCRIPTION
I didn't realize that the Baragon /state endpoint was reading from the global state node in ZK, I thought it was actually recomputing the state. This PR updates `getGlobalState` to actually recompute the state, which was the only value read of the global state so it paves the way for removing the global state node in the future. 

`getGlobalState` is called from:
- the agents on startup and after connection loss to ZooKeeper. I expect both of these events to be low volume but let me know if this assumption is wrong
- from the /state endpoint, but the work done in 87031a8532a06b43ecc52d1eae0aaba8686c590e should make it only call getGlobalState once per version node update

@tpetr @ssalinas 