### PR TITLE
Hack around the race condition when fetching upstream information

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -235,7 +235,9 @@ public class BaragonStateDatastore extends AbstractDataStore {
     }
 
     // Fetch upstream info for the modified services
-    serviceToUpstreamInfo.putAll(fetchServiceToUpstreamInfoMap(modifiedServices));
+    if (!modifiedServices.isEmpty()) {
+      serviceToUpstreamInfo.putAll(fetchServiceToUpstreamInfoMap(modifiedServices));
+    }
 
     return serviceToUpstreamInfo;
   }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -217,7 +217,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
 
       for (String upstream : entry.getValue()) {
         if (!serviceToUpstreamInfo.containsKey(entry.getKey())) {
-          serviceToUpstreamInfo.put(entry.getKey(), new ArrayList<UpstreamInfo>());
+          serviceToUpstreamInfo.put(service, new ArrayList<UpstreamInfo>());
         }
 
         Optional<UpstreamInfo> upstreamInfo = Optional.fromNullable(upstreamToInfo.get(upstream));

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -216,20 +216,15 @@ public class BaragonStateDatastore extends AbstractDataStore {
       String service = entry.getKey();
 
       for (String upstream : entry.getValue()) {
-        if (!upstreamToInfo.containsKey(upstream)) {
-          modifiedServices.add(service);
-        }
-      }
-
-      if (modifiedServices.contains(service)) {
-        continue;
-      }
-
-      for (String upstream : entry.getValue()) {
         if (!serviceToUpstreamInfo.containsKey(entry.getKey())) {
-          serviceToUpstreamInfo.put(entry.getKey(), Lists.newArrayList(upstreamToInfo.get(upstream)));
+          serviceToUpstreamInfo.put(entry.getKey(), new ArrayList<UpstreamInfo>());
+        }
+
+        Optional<UpstreamInfo> upstreamInfo = Optional.fromNullable(upstreamToInfo.get(upstream));
+        if (upstreamInfo.isPresent()) {
+          serviceToUpstreamInfo.get(service).add(upstreamInfo.get());
         } else {
-          serviceToUpstreamInfo.get(entry.getKey()).add(upstreamToInfo.get(upstream));
+          modifiedServices.add(service);
         }
       }
     }


### PR DESCRIPTION
We currently fetch the list of upstreams, and then the information about each of those upstreams as separate operations [here](https://github.com/HubSpot/Baragon/blob/a78bb42a8f3f2003de3c23bacf89e388fa3d8a1a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java#L205-L206). This creates a race condition because if the upstreams change, the maps won't line up and you'll end up with a `null` upstream [here](https://github.com/HubSpot/Baragon/blob/a78bb42a8f3f2003de3c23bacf89e388fa3d8a1a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java#L213) (because you're doing a `map.get` on a missing key). This PR hacks around the problem by storing the list of services whose upstreams changed during the fetch, and then refetching those at the end

@tpetr @ssalinas 