### PR TITLE
Install latest nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ MAINTAINER HubSpot <paas@hubspot.com>
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python-setuptools nginx sed && \
+    apt-get install -y python-setuptools sed && \
     easy_install supervisor && \
+    apt-get install -y -t jessie-backports nginx=1.9.4-1~bpo8+1 && \
     mkdir -p /etc/nginx/conf.d/custom && \
     mkdir -p /etc/nginx/conf.d/proxy && \
     mkdir -p /etc/nginx/conf.d/upstreams

--- a/Dockerfile-aurora
+++ b/Dockerfile-aurora
@@ -4,9 +4,10 @@ MAINTAINER HubSpot <paas@hubspot.com>
 # Used to build hubspot/baragonagentbase-aurora image
 
 RUN apt-get update && \
-    apt-get install -y python-setuptools nginx sed \
+    apt-get install -y python-setuptools sed \
       libapr1-dev libsasl2-dev libcurl4-nss-dev libsvn-dev && \
     easy_install supervisor && \
+    apt-get install -y -t jessie-backports nginx=1.9.4-1~bpo8+1 && \
     mkdir -p /etc/nginx/conf.d/custom && \
     mkdir -p /etc/nginx/conf.d/proxy && \
     mkdir -p /etc/nginx/conf.d/upstreams && \


### PR DESCRIPTION
This installs a newer nginx. Since R5([1.7.7](https://www.nginx.com/blog/tcp-load-balancing-in-nginx-plus-r5/)), nginx can do tcp load balancing but the nginx in `baragonagentbase` is older than that release.

Containers built with this are in the hub:
```
kasisnu/baragonagent-aurora:0.1.11-SNAPSHOT
kasisnu/baragonagent:0.1.11-SNAPSHOT
kasisnu/baragonagentbase-aurora:latest
kasisnu/baragonagentbase:latest
kasisnu/baragonservice:0.1.11-SNAPSHOT
```
The tests part of the maven build all passed, although I'm not sure if they were testing integration with nginx.

Nginx is locked to a known _working_ version since ... backports.


https://www.nginx.com/resources/admin-guide/nginx-plus-releases/