### PR TITLE
no agents should be a failed_reverted status

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -90,7 +90,7 @@ public class BaragonRequestWorker implements Runnable {
         for (String loadBalancerGroup : request.getLoadBalancerService().getLoadBalancerGroups()) {
           if (agentManager.invalidAgentCount(loadBalancerGroup)) {
             requestManager.setRequestMessage(request.getLoadBalancerRequestId(), String.format("Invalid request due to not enough agents present for group: %s", loadBalancerGroup));
-            return InternalRequestStates.INVALID_REQUEST_NOOP;
+            return InternalRequestStates.FAILED_REVERTED;
           }
         }
 


### PR DESCRIPTION
Want to change this to a FAILED_REVERTED status instead for a few reasons:
- Requests is not invalid in this case, it could still be applied if agents came back
- This will make Singularity keep retrying in the case where there aren't agents to service the request at first
- No agents to process is more of a failure than invalid, because at this point we have already checked the group exists, but have failed to find an agent to process the request