### PR TITLE
if data is empty, return Optional.absent

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
@@ -138,7 +138,12 @@ public abstract class AbstractDataStore {
 
   protected Optional<byte[]> readFromZk(String path) {
     try {
-      return Optional.of(curatorFramework.getData().forPath(path));
+      byte[] data = curatorFramework.getData().forPath(path);
+      if (data.length > 0) {
+        return Optional.of(curatorFramework.getData().forPath(path));
+      } else {
+        return Optional.absent();
+      }
     } catch (KeeperException.NoNodeException nne) {
       return Optional.absent();
     } catch (Exception e) {


### PR DESCRIPTION
Fixes the issue where we occasionally choke on requests that are blank, ran into this during some zk connectivity issues. A node was created for the request, but with no data or children, subsequent things that tried to fetch that request or response histories would fail