### PR TITLE
return true if any files exists

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
@@ -292,12 +292,12 @@ public class FilesystemConfigHelper {
 
   private boolean configsExist(BaragonService service) {
     for (String filename : configGenerator.getConfigPathsForProject(service)) {
-      if (!new File(filename).exists()) {
-        return false;
+      if (new File(filename).exists()) {
+        return true;
       }
     }
 
-    return true;
+    return false;
   }
 
   private void saveAsFailed(BaragonService service) {


### PR DESCRIPTION
Our logic uses `configsExists` to check if *any* old files exist and we need to operate on them. So, we should return true if we find any existing files instead of returning false if we find one that doesn't exist. Issues caused by this will only impact templates that don't use a certain file, and only in the DELETE case