### PR TITLE
wire up baragon service for sentry

### DIFF
--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -156,6 +156,10 @@
       <artifactId>zookeeper</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.kencochrane.raven</groupId>
+      <artifactId>raven</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jukito</groupId>
       <artifactId>jukito</artifactId>
       <scope>test</scope>

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -120,6 +120,10 @@
       <artifactId>dropwizard-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-jersey</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -28,6 +28,7 @@ import com.hubspot.baragon.data.BaragonConnectionStateListener;
 import com.hubspot.baragon.data.BaragonWorkerDatastore;
 import com.hubspot.baragon.service.config.BaragonConfiguration;
 import com.hubspot.baragon.service.config.ElbConfiguration;
+import com.hubspot.baragon.service.config.SentryConfiguration;
 import com.hubspot.baragon.service.listeners.AbstractLatchListener;
 import com.hubspot.baragon.service.listeners.BackgroundStateUpdatingListener;
 import com.hubspot.baragon.service.listeners.ElbSyncWorkerListener;
@@ -221,5 +222,11 @@ public class BaragonServiceModule extends AbstractModule {
     client.start();
 
     return client.usingNamespace(config.getZkNamespace());
+  }
+
+  @Provides
+  @Singleton
+  public Optional<SentryConfiguration> sentryConfiguration(final BaragonConfiguration config) {
+    return config.getSentryConfiguration();
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -91,6 +91,9 @@ public class BaragonConfiguration extends Configuration {
   @JsonProperty("graphite")
   private GraphiteConfiguration graphiteConfiguration = new GraphiteConfiguration();
 
+  @JsonProperty("sentry")
+  private SentryConfiguration sentryConfiguration;
+
   public ZooKeeperConfiguration getZooKeeperConfiguration() {
     return zooKeeperConfiguration;
   }
@@ -233,5 +236,13 @@ public class BaragonConfiguration extends Configuration {
 
   public void setGraphiteConfiguration(GraphiteConfiguration graphiteConfiguration) {
     this.graphiteConfiguration = graphiteConfiguration;
+  }
+
+  public SentryConfiguration getSentryConfiguration() {
+    return sentryConfiguration;
+  }
+
+  public void setSentryConfiguration(SentryConfiguration sentryConfiguration) {
+    this.sentryConfiguration = sentryConfiguration;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -92,7 +92,7 @@ public class BaragonConfiguration extends Configuration {
   private GraphiteConfiguration graphiteConfiguration = new GraphiteConfiguration();
 
   @JsonProperty("sentry")
-  private SentryConfiguration sentryConfiguration;
+  private Optional<SentryConfiguration> sentryConfiguration;
 
   public ZooKeeperConfiguration getZooKeeperConfiguration() {
     return zooKeeperConfiguration;
@@ -238,11 +238,11 @@ public class BaragonConfiguration extends Configuration {
     this.graphiteConfiguration = graphiteConfiguration;
   }
 
-  public SentryConfiguration getSentryConfiguration() {
+  public Optional<SentryConfiguration> getSentryConfiguration() {
     return sentryConfiguration;
   }
 
-  public void setSentryConfiguration(SentryConfiguration sentryConfiguration) {
+  public void setSentryConfiguration(Optional<SentryConfiguration> sentryConfiguration) {
     this.sentryConfiguration = sentryConfiguration;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/SentryConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/SentryConfiguration.java
@@ -1,0 +1,31 @@
+package com.hubspot.baragon.service.config;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SentryConfiguration {
+
+  @NotEmpty
+  @JsonProperty("dsn")
+  private String dsn;
+
+  @JsonProperty("prefix")
+  private String prefix = "";
+
+  public String getDsn() {
+    return dsn;
+  }
+
+  public void setDsn(String dsn) {
+    this.dsn = dsn;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/BaragonExceptionNotifier.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/BaragonExceptionNotifier.java
@@ -1,0 +1,103 @@
+package com.hubspot.baragon.service.exceptions;
+
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.hubspot.baragon.service.config.SentryConfiguration;
+
+import net.kencochrane.raven.Raven;
+import net.kencochrane.raven.RavenFactory;
+import net.kencochrane.raven.event.Event;
+import net.kencochrane.raven.event.EventBuilder;
+import net.kencochrane.raven.event.interfaces.ExceptionInterface;
+
+@Singleton
+public class BaragonExceptionNotifier {
+  private static final Logger LOG = LoggerFactory.getLogger(BaragonExceptionNotifier.class);
+
+  private final Optional<Raven> raven;
+  private final Optional<SentryConfiguration> sentryConfiguration;
+
+  @Inject
+  public BaragonExceptionNotifier(Optional<SentryConfiguration> sentryConfiguration) {
+    this.sentryConfiguration = sentryConfiguration;
+    if (sentryConfiguration.isPresent()) {
+      this.raven = Optional.of(RavenFactory.ravenInstance(sentryConfiguration.get().getDsn()));
+    } else {
+      this.raven = Optional.absent();
+    }
+  }
+
+  private String getPrefix() {
+    if (!sentryConfiguration.isPresent() || Strings.isNullOrEmpty(sentryConfiguration.get().getPrefix())) {
+      return "";
+    }
+
+    return sentryConfiguration.get().getPrefix() + " ";
+  }
+
+  private String getCallingClassName(StackTraceElement[] stackTrace) {
+    if (stackTrace != null && stackTrace.length > 2) {
+      return stackTrace[2].getClassName();
+    } else {
+      return "(unknown)";
+    }
+  }
+
+  private void sendEvent(Raven raven, final EventBuilder eventBuilder) {
+    raven.runBuilderHelpers(eventBuilder);
+
+    raven.sendEvent(eventBuilder.build());
+  }
+
+  public void notify(Throwable t, Map<String, String> extraData) {
+    if (!raven.isPresent()) {
+      return;
+    }
+
+    final StackTraceElement[] currentThreadStackTrace = Thread.currentThread().getStackTrace();
+
+    final EventBuilder eventBuilder = new EventBuilder()
+        .withCulprit(getPrefix() + t.getMessage())
+        .withMessage(Strings.nullToEmpty(t.getMessage()))
+        .withLevel(Event.Level.ERROR)
+        .withLogger(getCallingClassName(currentThreadStackTrace))
+        .withSentryInterface(new ExceptionInterface(t));
+
+    if (extraData != null && !extraData.isEmpty()) {
+      for (Map.Entry<String, String> entry : extraData.entrySet()) {
+        eventBuilder.withExtra(entry.getKey(), entry.getValue());
+      }
+    }
+
+    sendEvent(raven.get(), eventBuilder);
+  }
+
+  public void notify(String subject, Map<String, String> extraData) {
+    if (!raven.isPresent()) {
+      return;
+    }
+
+    final StackTraceElement[] currentThreadStackTrace = Thread.currentThread().getStackTrace();
+
+    final EventBuilder eventBuilder = new EventBuilder()
+        .withMessage(getPrefix() + subject)
+        .withLevel(Event.Level.ERROR)
+        .withLogger(getCallingClassName(currentThreadStackTrace));
+
+    if (extraData != null && !extraData.isEmpty()) {
+      for (Map.Entry<String, String> entry : extraData.entrySet()) {
+        eventBuilder.withExtra(entry.getKey(), entry.getValue());
+      }
+    }
+
+    sendEvent(raven.get(), eventBuilder);
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NotifyingExceptionMapper.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NotifyingExceptionMapper.java
@@ -1,0 +1,31 @@
+package com.hubspot.baragon.service.exceptions;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.Response;
+
+import com.google.inject.Inject;
+
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
+
+@javax.ws.rs.ext.Provider
+public class NotifyingExceptionMapper extends LoggingExceptionMapper<Exception> {
+  private final BaragonExceptionNotifier notifier;
+
+  @Inject
+  public NotifyingExceptionMapper(BaragonExceptionNotifier notifier) {
+    this.notifier = notifier;
+  }
+
+  @Override
+  public Response toResponse(final Exception e) {
+    final Response response = super.toResponse(e);
+
+    if (response.getStatus() >= 500) {
+      notifier.notify(e, Collections.<String, String>emptyMap());
+    }
+
+    return response;
+  }
+}
+

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NotifyingUncaughtExceptionManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NotifyingUncaughtExceptionManager.java
@@ -1,0 +1,23 @@
+package com.hubspot.baragon.service.exceptions;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NotifyingUncaughtExceptionManager implements UncaughtExceptionHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NotifyingUncaughtExceptionManager.class);
+
+  private final BaragonExceptionNotifier notifier;
+
+  public NotifyingUncaughtExceptionManager(BaragonExceptionNotifier notifier) {
+    this.notifier = notifier;
+  }
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    LOG.error("Uncaught exception!", e);
+    notifier.notify(e, Collections.<String, String>emptyMap());
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managed/BaragonExceptionNotifierManaged.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managed/BaragonExceptionNotifierManaged.java
@@ -1,0 +1,37 @@
+package com.hubspot.baragon.service.managed;
+
+
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.hubspot.baragon.service.exceptions.BaragonExceptionNotifier;
+import com.hubspot.baragon.service.exceptions.NotifyingExceptionMapper;
+import com.hubspot.baragon.service.exceptions.NotifyingUncaughtExceptionManager;
+
+import io.dropwizard.lifecycle.Managed;
+
+@Singleton
+public class BaragonExceptionNotifierManaged implements Managed {
+  private static final Logger LOG = LoggerFactory.getLogger(NotifyingExceptionMapper.class);
+
+  private final BaragonExceptionNotifier exceptionNotifier;
+
+  @Inject
+  public BaragonExceptionNotifierManaged(BaragonExceptionNotifier exceptionNotifier) {
+    this.exceptionNotifier = exceptionNotifier;
+  }
+
+  @Override
+  public void start() throws Exception {
+    LOG.info("Setting NotifyingUncaughtExceptionManager as the default uncaught exception provider...");
+    Thread.setDefaultUncaughtExceptionHandler(new NotifyingUncaughtExceptionManager(exceptionNotifier));
+  }
+
+  @Override
+  public void stop() throws Exception {
+
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
@@ -47,7 +47,7 @@ public class AgentCheckinResource {
       }
     } catch (Exception e) {
       LOG.error("Could not register agent startup", e);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e).build();
     }
     return Response.ok().build();
   }
@@ -62,7 +62,7 @@ public class AgentCheckinResource {
       }
     } catch (Exception e) {
       LOG.error("Could not register agent shutdown", e);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e).build();
     }
     return Response.ok().build();
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
@@ -47,7 +47,7 @@ public class AgentCheckinResource {
       }
     } catch (Exception e) {
       LOG.error("Could not register agent startup", e);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
     }
     return Response.ok().build();
   }
@@ -62,7 +62,7 @@ public class AgentCheckinResource {
       }
     } catch (Exception e) {
       LOG.error("Could not register agent shutdown", e);
-      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e).build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build();
     }
     return Response.ok().build();
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonBackgroundStateUpdatingWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonBackgroundStateUpdatingWorker.java
@@ -4,9 +4,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.service.exceptions.BaragonExceptionNotifier;
 
 @Singleton
 public class BaragonBackgroundStateUpdatingWorker implements Runnable {
@@ -14,11 +16,13 @@ public class BaragonBackgroundStateUpdatingWorker implements Runnable {
 
   private final BaragonStateDatastore stateDatastore;
   private Optional<Integer> lastUpdateId;
+  private final BaragonExceptionNotifier exceptionNotifier;
 
   @Inject
-  public BaragonBackgroundStateUpdatingWorker(BaragonStateDatastore stateDatastore) {
+  public BaragonBackgroundStateUpdatingWorker(BaragonStateDatastore stateDatastore, BaragonExceptionNotifier exceptionNotifier) {
     this.stateDatastore = stateDatastore;
     this.lastUpdateId = Optional.absent();
+    this.exceptionNotifier = exceptionNotifier;
   }
 
   @Override
@@ -39,6 +43,7 @@ public class BaragonBackgroundStateUpdatingWorker implements Runnable {
       }
     } catch (Exception e) {
       LOG.error("Caught exception during state node update", e);
+      exceptionNotifier.notify(e, ImmutableMap.of("lastUpdateId", lastUpdateId.toString()));
     }
   }
 }


### PR DESCRIPTION
/cc @tpetr 
Gets BaragonService ready for sentry. I didn't do the agents initially here since exceptions from the agents will generally come back as failed apply requests. In the service I wired up for uncaught exceptions, 50* responses, and a few catch blocks in different workers