### PR TITLE
configurably check for vpc to match between elb and instance

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
@@ -13,21 +13,25 @@ public class BaragonAgentEc2Metadata {
   private final Optional<String> instanceId;
   private final Optional<String> availabilityZone;
   private final Optional<String> subnetId;
+  private final Optional<String> vpcId;
 
   @JsonCreator
   public BaragonAgentEc2Metadata(@JsonProperty("instanceId") Optional<String> instanceId,
                                  @JsonProperty("availabilityZone") Optional<String> availabilityZone,
-                                 @JsonProperty("subnetId") Optional<String> subnetId) {
+                                 @JsonProperty("subnetId") Optional<String> subnetId,
+                                 @JsonProperty("vpcId") Optional<String> vpcId) {
     this.instanceId = instanceId;
     this.availabilityZone = availabilityZone;
     this.subnetId = subnetId;
+    this.vpcId = vpcId;
   }
 
   public static BaragonAgentEc2Metadata fromEnvironment() {
     return new BaragonAgentEc2Metadata(
       findInstanceId(),
       findAvailabilityZone(),
-      findSubnet());
+      findSubnet(),
+      findVpc());
   }
 
   public static Optional<String> findInstanceId() {
@@ -59,6 +63,19 @@ public class BaragonAgentEc2Metadata {
     }
   }
 
+  private static Optional<String> findVpc() {
+    try {
+      List<EC2MetadataUtils.NetworkInterface> networkInterfaces = EC2MetadataUtils.getNetworkInterfaces();
+      if (EC2MetadataUtils.getNetworkInterfaces().isEmpty()) {
+        return Optional.absent();
+      } else {
+        return Optional.fromNullable(networkInterfaces.get(0).getVpcId());
+      }
+    } catch (Exception e) {
+      return Optional.absent();
+    }
+  }
+
   public Optional<String> getInstanceId() {
     return instanceId;
   }
@@ -69,5 +86,9 @@ public class BaragonAgentEc2Metadata {
 
   public Optional<String> getSubnetId() {
     return subnetId;
+  }
+
+  public Optional<String> getVpcId() {
+    return vpcId;
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -30,7 +30,7 @@ public class BaragonAgentMetadata {
       throw new InvalidAgentMetadataStringException(value);
     }
 
-    return new BaragonAgentMetadata(value, matcher.group(1), Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap());
+    return new BaragonAgentMetadata(value, matcher.group(1), Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap());
   }
 
   @JsonCreator

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/ElbConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/ElbConfiguration.java
@@ -37,6 +37,12 @@ public class ElbConfiguration {
   @JsonProperty("deregisterEnabled")
   private boolean deregisterEnabled = false;
 
+  @JsonProperty("failWhenNoElbForVpc")
+  private boolean failWhenNoElbForVpc = true;
+
+  @JsonProperty("checkForCorrectVpc")
+  private boolean checkForCorrectVpc = true;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -107,5 +113,21 @@ public class ElbConfiguration {
 
   public void setRemoveKnownAgentMinutes(int removeKnownAgentMinutes) {
     this.removeKnownAgentMinutes = removeKnownAgentMinutes;
+  }
+
+  public boolean isFailWhenNoElbForVpc() {
+    return failWhenNoElbForVpc;
+  }
+
+  public void setFailWhenNoElbForVpc(boolean failWhenNoElbForVpc) {
+    this.failWhenNoElbForVpc = failWhenNoElbForVpc;
+  }
+
+  public boolean isCheckForCorrectVpc() {
+    return checkForCorrectVpc;
+  }
+
+  public void setCheckForCorrectVpc(boolean checkForCorrectVpc) {
+    this.checkForCorrectVpc = checkForCorrectVpc;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/ElbConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/ElbConfiguration.java
@@ -38,10 +38,10 @@ public class ElbConfiguration {
   private boolean deregisterEnabled = false;
 
   @JsonProperty("failWhenNoElbForVpc")
-  private boolean failWhenNoElbForVpc = true;
+  private boolean failWhenNoElbForVpc = false;
 
   @JsonProperty("checkForCorrectVpc")
-  private boolean checkForCorrectVpc = true;
+  private boolean checkForCorrectVpc = false;
 
   public boolean isEnabled() {
     return enabled;

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NoMatchingElbForVpcException.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/exceptions/NoMatchingElbForVpcException.java
@@ -1,0 +1,7 @@
+package com.hubspot.baragon.service.exceptions;
+
+public class NoMatchingElbForVpcException extends Exception {
+  public NoMatchingElbForVpcException(String message) {
+    super(message);
+  }
+}

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTests.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTests.java
@@ -33,7 +33,7 @@ public class KnownAgentTests {
 
   @Test
   public void testKnownAgentBaragonMetadata(BaragonKnownAgentsDatastore datastore) {
-    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), System.currentTimeMillis());
+    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), System.currentTimeMillis());
     datastore.addKnownAgent(CLUSTER_NAME, metadata);
 
     assertEquals(Collections.singletonList(metadata), datastore.getKnownAgentsMetadata(CLUSTER_NAME));
@@ -41,7 +41,7 @@ public class KnownAgentTests {
 
   @Test
   public void testKnownAgentString() {
-    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap()), BaragonAgentMetadata.fromString(BASE_URI));
+    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap()), BaragonAgentMetadata.fromString(BASE_URI));
   }
 
   @Test( expected = InvalidAgentMetadataStringException.class )


### PR DESCRIPTION
You can't have an instance join an elb in a different vpc. Baragon shouldn't be trying to do something we know will error. We can now do a few things with some added settings:
- `checkForCorrectVpc` - turn on checks for vpc, defaults to `false` which gives us the same behavior as we have currently where we will try to add the instance anyway
- `failWhenNoElbForVpc` - if we have found an elb that matches the group, but not one that matches the vpc, throw an exception (i.e. enforce that we have an elb available for all the vpcs our agents are running in), defaults to `false`