### PR TITLE
make sure we own the lock before any actions that can return success

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
@@ -128,6 +128,10 @@ public class FilesystemConfigHelper {
 
     Collection<BaragonConfigFile> newConfigs = configGenerator.generateConfigsForProject(context);
 
+    if (!agentLock.tryLock(agentLockTimeoutMs, TimeUnit.MILLISECONDS)) {
+      throw new LockTimeoutException("Timed out waiting to acquire lock", agentLock);
+    }
+
     if (configsMatch(newConfigs, readConfigs(oldService))) {
       LOG.info("    Configs are unchanged, skipping apply");
       return;
@@ -139,10 +143,6 @@ public class FilesystemConfigHelper {
       if (oldServiceExists) {
         backupConfigs(oldService);
       }
-    }
-
-    if (!agentLock.tryLock(agentLockTimeoutMs, TimeUnit.MILLISECONDS)) {
-      throw new LockTimeoutException("Timed out waiting to acquire lock", agentLock);
     }
 
     // Write & check the configs


### PR DESCRIPTION
order of events that caused an issue:
- BaragonService issues attempt 1 to update configs to agent
- Agent processes that request but config check is slow
- BaragonService times out and sends attempt 2
- Attempt 2 on agent sees the configs are unchanged (already applied from attempt 1 which hasn't finished checking yet) and returns success to BaragonService
- Attempt 1 comes back with invalid configs and reverts to old configs

This series of events causes the agent that timed out to be behind in configs by 1 deploy. This PR moves the lock acquisition earlier so that we need to own that lock for any action that could possibly return a success to BaragonService