### PR TITLE
don't require lock for a delete

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -313,8 +313,10 @@ public class RequestManager {
   private void clearBasePathsWithNoUpstreams(BaragonRequest request) {
     try {
       if (stateDatastore.getUpstreams(request.getLoadBalancerService().getServiceId()).isEmpty()) {
-        for (String loadbalancerGroup : request.getLoadBalancerService().getLoadBalancerGroups()) {
-          loadBalancerDatastore.clearBasePath(loadbalancerGroup, request.getLoadBalancerService().getServiceBasePath());
+        for (String loadBalancerGroup : request.getLoadBalancerService().getLoadBalancerGroups()) {
+          if (loadBalancerDatastore.getBasePathServiceId(loadBalancerGroup, request.getLoadBalancerService().getServiceBasePath()).or("").equals(request.getLoadBalancerService().getServiceId())) {
+            loadBalancerDatastore.clearBasePath(loadBalancerGroup, request.getLoadBalancerService().getServiceBasePath());
+          }
         }
       }
     } catch (Exception e) {
@@ -325,7 +327,9 @@ public class RequestManager {
   private void clearChangedBasePaths(BaragonRequest request, Optional<BaragonService> maybeOriginalService) {
     if (maybeOriginalService.isPresent() && !maybeOriginalService.get().getServiceBasePath().equals(request.getLoadBalancerService().getServiceBasePath())) {
       for (String loadBalancerGroup : maybeOriginalService.get().getLoadBalancerGroups()) {
-        loadBalancerDatastore.clearBasePath(loadBalancerGroup, maybeOriginalService.get().getServiceBasePath());
+        if (loadBalancerDatastore.getBasePathServiceId(loadBalancerGroup, maybeOriginalService.get().getServiceBasePath()).or("").equals(maybeOriginalService.get().getServiceId())) {
+          loadBalancerDatastore.clearBasePath(loadBalancerGroup, maybeOriginalService.get().getServiceBasePath());
+        }
       }
     }
   }
@@ -336,8 +340,10 @@ public class RequestManager {
       removedLbGroups.removeAll(request.getLoadBalancerService().getLoadBalancerGroups());
       if (!removedLbGroups.isEmpty()) {
         try {
-          for (String loadbalancerGroup : removedLbGroups) {
-            loadBalancerDatastore.clearBasePath(loadbalancerGroup, maybeOriginalService.get().getServiceBasePath());
+          for (String loadBalancerGroup : removedLbGroups) {
+            if (loadBalancerDatastore.getBasePathServiceId(loadBalancerGroup, maybeOriginalService.get().getServiceBasePath()).or("").equals(maybeOriginalService.get().getServiceId())) {
+              loadBalancerDatastore.clearBasePath(loadBalancerGroup, maybeOriginalService.get().getServiceBasePath());
+            }
           }
         } catch (Exception e) {
           LOG.info(String.format("Error clearing base path %s", e));

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -83,7 +83,7 @@ public class BaragonRequestWorker implements Runnable {
       case PENDING:
         final Map<String, String> conflicts = requestManager.getBasePathConflicts(request);
 
-        if (!conflicts.isEmpty()) {
+        if (!conflicts.isEmpty() && !(request.getAction().or(RequestAction.UPDATE) == RequestAction.DELETE)) {
           requestManager.setRequestMessage(request.getLoadBalancerRequestId(), String.format("Invalid request due to base path conflicts: %s", conflicts));
           return InternalRequestStates.INVALID_REQUEST_NOOP;
         }
@@ -102,7 +102,9 @@ public class BaragonRequestWorker implements Runnable {
           }
         }
 
-        requestManager.lockBasePaths(request);
+        if (!(request.getAction().or(RequestAction.UPDATE) == RequestAction.DELETE)) {
+          requestManager.lockBasePaths(request);
+        }
 
         return InternalRequestStates.SEND_APPLY_REQUESTS;
 


### PR DESCRIPTION
In the delete case, very often we have already released the lock on the `basePath` due to having 0 upstreams present. In a delete we are only removing config files matching the service and releasing matching locks if they do exist. There is no reason we need to lock the base path to do this as long as we check that we own the lock before clearing it. This will keep Singularity from infinitely retrying/failing on certain deletes because the basePath has already been taken over by another service