### PR TITLE
Upgrade Horizon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ git:
   depth: 100
 sudo: false
 
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - unzip -qq apache-maven-3.3.9-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.3.9
+  - export PATH=$M2_HOME/bin:$PATH
+
 cache:
   directories:
   - $HOME/.m2

--- a/BaragonWatcher/pom.xml
+++ b/BaragonWatcher/pom.xml
@@ -46,32 +46,14 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.7</version>
+    <version>15.1</version>
   </parent>
 
   <artifactId>Baragon</artifactId>
@@ -29,7 +29,7 @@
 
   <properties>
     <curator.version>2.8.0</curator.version>
-    <horizon.version>0.0.20</horizon.version>
+    <horizon.version>0.0.22</horizon.version>
     <ringleader.version>0.1.5</ringleader.version>
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
     <mesos.docker.tag>0.21.1-1.1.ubuntu1404</mesos.docker.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.8</version>
+    <version>12.9</version>
   </parent>
 
   <artifactId>Baragon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <curator.version>2.8.0</curator.version>
-    <horizon.version>0.0.13</horizon.version>
+    <horizon.version>0.0.20</horizon.version>
     <ringleader.version>0.1.5</ringleader.version>
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
     <mesos.docker.tag>0.21.1-1.1.ubuntu1404</mesos.docker.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>15.1</version>
+    <version>12.8</version>
   </parent>
 
   <artifactId>Baragon</artifactId>


### PR DESCRIPTION
The new version of Horizon makes the async client use daemon threads which helps to ensure the JVM shuts down gracefully