### PR TITLE
handlerbars helper to calculate weights

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -26,6 +26,7 @@ import com.hubspot.baragon.agent.handlebars.CurrentRackIsPresentHelper;
 import com.hubspot.baragon.agent.handlebars.FirstOfHelper;
 import com.hubspot.baragon.agent.handlebars.FormatTimestampHelper;
 import com.hubspot.baragon.agent.handlebars.IfEqualHelperSource;
+import com.hubspot.baragon.agent.handlebars.PreferSameRackWeightingHelper;
 import com.hubspot.baragon.agent.listeners.ResyncListener;
 import com.hubspot.baragon.agent.models.LbConfigTemplate;
 import com.hubspot.baragon.config.AuthConfiguration;
@@ -72,6 +73,7 @@ public class BaragonAgentServiceModule extends AbstractModule {
     handlebars.registerHelper("formatTimestamp", new FormatTimestampHelper(config.getDefaultDateFormat()));
     handlebars.registerHelper("firstOf", new FirstOfHelper(""));
     handlebars.registerHelper("currentRackIsPresent", new CurrentRackIsPresentHelper(agentMetadata.getEc2().getAvailabilityZone()));
+    handlebars.registerHelpers(new PreferSameRackWeightingHelper(config, agentMetadata));
     handlebars.registerHelpers(IfEqualHelperSource.class);
 
     return handlebars;

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -103,6 +103,15 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("maxGetGloablStateAttempts")
   private int maxGetGloablStateAttempts = 3;
 
+  @JsonProperty("zeroWeightString")
+  private String zeroWeightString = "backup";
+
+  @JsonProperty("sameRackMultiplier")
+  private int sameRackMultiplier = 2;
+
+  @JsonProperty("weightingFormat")
+  private String weightingFormat = "weight=%s";
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -281,5 +290,29 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setMaxGetGloablStateAttempts(int maxGetGloablStateAttempts) {
     this.maxGetGloablStateAttempts = maxGetGloablStateAttempts;
+  }
+
+  public String getZeroWeightString() {
+    return zeroWeightString;
+  }
+
+  public void setZeroWeightString(String zeroWeightString) {
+    this.zeroWeightString = zeroWeightString;
+  }
+
+  public int getSameRackMultiplier() {
+    return sameRackMultiplier;
+  }
+
+  public void setSameRackMultiplier(int sameRackMultiplier) {
+    this.sameRackMultiplier = sameRackMultiplier;
+  }
+
+  public String getWeightingFormat() {
+    return weightingFormat;
+  }
+
+  public void setWeightingFormat(String weightingFormat) {
+    this.weightingFormat = weightingFormat;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.agent.handlebars;
 
 import java.util.Collection;
 
+import com.github.jknack.handlebars.Options;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
@@ -17,7 +18,7 @@ public class PreferSameRackWeightingHelper {
     this.agentMetadata = agentMetadata;
   }
 
-  public CharSequence preferSameRackWeighting(Collection<UpstreamInfo> upstreams, UpstreamInfo currentUpstream) {
+  public CharSequence preferSameRackWeighting(Collection<UpstreamInfo> upstreams, UpstreamInfo currentUpstream, Options options) {
     if (agentMetadata.getEc2().getAvailabilityZone().isPresent() && currentUpstream.getRackId().isPresent()) {
       String currentRack = agentMetadata.getEc2().getAvailabilityZone().get();
       int maxCount = 0;

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
@@ -1,0 +1,53 @@
+package com.hubspot.baragon.agent.handlebars;
+
+import java.util.Collection;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
+import com.hubspot.baragon.models.BaragonAgentMetadata;
+import com.hubspot.baragon.models.UpstreamInfo;
+
+public class PreferSameRackWeightingHelper {
+  private final BaragonAgentConfiguration configuration;
+  private final BaragonAgentMetadata agentMetadata;
+
+  public PreferSameRackWeightingHelper(BaragonAgentConfiguration configuration, BaragonAgentMetadata agentMetadata) {
+    this.configuration = configuration;
+    this.agentMetadata = agentMetadata;
+  }
+
+  public CharSequence preferSameRackWeighting(Collection<UpstreamInfo> upstreams, UpstreamInfo currentUpstream) {
+    if (agentMetadata.getEc2().getAvailabilityZone().isPresent() && currentUpstream.getRackId().isPresent()) {
+      String currentRack = agentMetadata.getEc2().getAvailabilityZone().get();
+      int maxCount = 0;
+      Multiset<String> racks = HashMultiset.create();
+      for (UpstreamInfo upstreamInfo : upstreams) {
+        if (upstreamInfo.getRackId().isPresent()) {
+          racks.add(upstreamInfo.getRackId().get());
+          if (racks.count(upstreamInfo.getRackId().get()) > maxCount) {
+            maxCount = racks.count(upstreamInfo.getRackId().get());
+          }
+        }
+      }
+
+      if (racks.count(currentRack) == 0) {
+        return "";
+      }
+
+      if (racks.count(currentRack) == maxCount) {
+        if (currentUpstream.getRackId().get().equals(currentRack)) {
+          return "";
+        } else {
+          return configuration.getZeroWeightString();
+        }
+      } else {
+        if (currentUpstream.getRackId().get().equals(currentRack)) {
+          return String.format(configuration.getWeightingFormat(), configuration.getSameRackMultiplier());
+        }
+      }
+    }
+
+    return "";
+  }
+}


### PR DESCRIPTION
Helper that will spit out weights of servers so that we can prefer traffic in our same rack while still routing evenly if the upstream count in each rack is uneven