### PR TITLE
make sure a duplicate upstream with no rack is not deleted

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -144,12 +144,13 @@ public class BaragonStateDatastore extends AbstractDataStore {
         List<String> matchingUpstreamPaths = matchingUpstreamPaths(currentUpstreams, upstreamInfo);
         for (String matchingPath : matchingUpstreamPaths) {
           String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
-          if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath)) {
+          if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath) && !fullPath.equals(addPath)) {
+            LOG.info(String.format("Deleting %s", fullPath));
             pathsToDelete.add(fullPath);
             transaction.delete().forPath(fullPath);
           }
         }
-        if (!nodeExists(addPath)) {
+        if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {
           transaction.create().forPath(addPath).and();
         }
       }


### PR DESCRIPTION
As part of the move to storing all upstream info in the path we added some logic to remove an upstream that might be the same host:port but a different requestId/rack. In a specific case (only found it in testing so far) where the requestId is the same on an identical upstream in addUpstreams it will be incorrectly removed.

Chances that this impacted any actual running things are slim to none since Baragon will default the requestId appropriately if not set and Singularity will set it appropriately. Still, good to fix it :)