### PR TITLE
if no domains in list match agent, check for default domain

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -96,6 +96,11 @@ public class LbConfigGenerator {
               filenames.add(String.format(template.getFilename(), domain, service.getServiceId()));
             }
           }
+          if (filenames.isEmpty() && loadBalancerConfiguration.getDefaultDomain().isPresent()) {
+            filenames.add(String.format(template.getFilename(), loadBalancerConfiguration.getDefaultDomain().get(), service.getServiceId()));
+          } else {
+            throw new IllegalStateException("No domain served for template file that requires domain");
+          }
         } else if (loadBalancerConfiguration.getDefaultDomain().isPresent()){
           filenames.add(String.format(template.getFilename(), loadBalancerConfiguration.getDefaultDomain().get(), service.getServiceId()));
         } else {


### PR DESCRIPTION
I was using a check to see if the domains list was empty or not to determine if we check the default domain. We also need to check again for default domain if nothing in the provided list matches this agent's served domains. 

In other words, fall back to default on that group for a service hosted on multiple groups where some do and some don't serve multiple domains.

@tpetr