### PR TITLE
restructure check for empty filenames list

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -96,10 +96,12 @@ public class LbConfigGenerator {
               filenames.add(String.format(template.getFilename(), domain, service.getServiceId()));
             }
           }
-          if (filenames.isEmpty() && loadBalancerConfiguration.getDefaultDomain().isPresent()) {
-            filenames.add(String.format(template.getFilename(), loadBalancerConfiguration.getDefaultDomain().get(), service.getServiceId()));
-          } else {
-            throw new IllegalStateException("No domain served for template file that requires domain");
+          if (filenames.isEmpty()) {
+            if (loadBalancerConfiguration.getDefaultDomain().isPresent()) {
+              filenames.add(String.format(template.getFilename(), loadBalancerConfiguration.getDefaultDomain().get(), service.getServiceId()));
+            } else {
+              throw new IllegalStateException("No domain served for template file that requires domain");
+            }
           }
         } else if (loadBalancerConfiguration.getDefaultDomain().isPresent()){
           filenames.add(String.format(template.getFilename(), loadBalancerConfiguration.getDefaultDomain().get(), service.getServiceId()));


### PR DESCRIPTION
@tpetr found one more case for this, restructuring the if statements a bit so we don't inccorectly throw an error when we've found valid domains