### PR TITLE
add support for upstream groups

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -1,14 +1,5 @@
 package com.hubspot.baragon.agent.managers;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicReference;
-
-import javax.ws.rs.core.Response;
-
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -29,6 +20,13 @@ import com.hubspot.baragon.models.ServiceContext;
 import com.hubspot.baragon.models.UpstreamInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.ws.rs.core.Response;
 
 @Singleton
 public class AgentRequestManager {
@@ -164,13 +162,13 @@ public class AgentRequestManager {
         boolean present = false;
         boolean toRemove = false;
         for (UpstreamInfo currentUpstream : upstreams) {
-          if (currentUpstream.sameAs(existingUpstream)) {
+          if (UpstreamInfo.upstreamAndGroupMatches(currentUpstream, existingUpstream)) {
             present = true;
             break;
           }
         }
         for (UpstreamInfo upstreamToRemove : request.getRemoveUpstreams()) {
-          if (upstreamToRemove.sameAs(existingUpstream)) {
+          if (UpstreamInfo.upstreamAndGroupMatches(upstreamToRemove, existingUpstream)) {
             toRemove = true;
             break;
           }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -122,7 +122,7 @@ public class BaragonRequest {
 
   private UpstreamInfo addRequestId(UpstreamInfo upstream, String requestId) {
     if (!upstream.getRequestId().isPresent()) {
-      return new UpstreamInfo(upstream.getUpstream(), Optional.of(requestId), upstream.getRackId());
+      return new UpstreamInfo(upstream.getUpstream(), Optional.of(requestId), upstream.getRackId(), Optional.of(upstream.getGroup()));
     } else {
       return upstream;
     }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceContext {
-  public static final String DEFAULT_UPSTREAM_GROUP = "default";
-
   private final BaragonService service;
   private final Collection<UpstreamInfo> upstreams;
   private final Map<String, Collection<UpstreamInfo>> upstreamGroups;
@@ -36,7 +34,7 @@ public class ServiceContext {
     if (!this.upstreams.isEmpty()) {
       final Multimap<String, UpstreamInfo> upstreamGroupsMultimap = ArrayListMultimap.create();
       for (UpstreamInfo upstream : this.upstreams) {
-        upstreamGroupsMultimap.put(upstream.getGroup().or(DEFAULT_UPSTREAM_GROUP), upstream);
+        upstreamGroupsMultimap.put(upstream.getGroup(), upstream);
       }
       this.upstreamGroups = upstreamGroupsMultimap.asMap();
     } else {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
@@ -1,17 +1,23 @@
 package com.hubspot.baragon.models;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceContext {
+  public static final String DEFAULT_UPSTREAM_GROUP = "default";
+
   private final BaragonService service;
   private final Collection<UpstreamInfo> upstreams;
+  private final Map<String, Collection<UpstreamInfo>> upstreamGroups;
   private final Long timestamp;
   private final boolean present;
   private final boolean rootPath;
@@ -26,6 +32,16 @@ public class ServiceContext {
     this.upstreams = Objects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList());
     this.present = present;
     this.rootPath = service.getServiceBasePath().equals("/");
+
+    if (!this.upstreams.isEmpty()) {
+      final Multimap<String, UpstreamInfo> upstreamGroupsMultimap = ArrayListMultimap.create();
+      for (UpstreamInfo upstream : this.upstreams) {
+        upstreamGroupsMultimap.put(upstream.getGroup().or(DEFAULT_UPSTREAM_GROUP), upstream);
+      }
+      this.upstreamGroups = upstreamGroupsMultimap.asMap();
+    } else {
+      this.upstreamGroups = Collections.emptyMap();
+    }
   }
 
   public BaragonService getService() {
@@ -34,6 +50,10 @@ public class ServiceContext {
 
   public Collection<UpstreamInfo> getUpstreams() {
     return upstreams;
+  }
+
+  public Map<String, Collection<UpstreamInfo>> getUpstreamGroups() {
+    return upstreamGroups;
   }
 
   public Long getTimestamp() {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
@@ -24,9 +24,6 @@ public class UpstreamInfo {
   @Pattern(regexp = "^$|[^\\s|]+", message = "cannot contain whitespace, '/', or '|'")
   private final String rackId;
   private final Optional<String> originalPath;
-
-  @Size(max=100)
-  @Pattern(regexp = "^$|[^\\s|]+", message = "cannot contain whitespace, '/', or '|'")
   private final Optional<String> group;
 
   @JsonCreator
@@ -47,8 +44,12 @@ public class UpstreamInfo {
     return new UpstreamInfo(upstream, Optional.<String>absent(), Optional.<String>absent(), Optional.of(upstream), Optional.<String>absent());
   }
 
-  public UpstreamInfo (String upstream, Optional<String> requestId, Optional<String> rackId) {
+  public UpstreamInfo(String upstream, Optional<String> requestId, Optional<String> rackId) {
     this(upstream, requestId, rackId, Optional.<String>absent(), Optional.<String>absent());
+  }
+
+  public UpstreamInfo(String upstream, Optional<String> requestId, Optional<String> rackId, Optional<String> group) {
+    this(upstream, requestId, rackId, Optional.<String>absent(), group);
   }
 
   @JsonCreator

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
@@ -16,6 +16,10 @@ import javax.validation.constraints.Size;
 public class UpstreamInfo {
   public static final String DEFAULT_GROUP = "default";
 
+  public static boolean upstreamAndGroupMatches(UpstreamInfo a, UpstreamInfo b) {
+    return a.getUpstream().equals(b.getUpstream()) && a.getGroup().equals(b.getGroup());
+  }
+
   private final String upstream;
 
   @Size(max=250)
@@ -132,10 +136,6 @@ public class UpstreamInfo {
     }
 
     return true;
-  }
-
-  public boolean sameAs(UpstreamInfo that) {
-    return upstream.equals(that.upstream) && group.equals(that.group);
   }
 
   @Override

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
@@ -134,6 +134,10 @@ public class UpstreamInfo {
     return true;
   }
 
+  public boolean sameAs(UpstreamInfo that) {
+    return upstream.equals(that.upstream) && group.equals(that.group);
+  }
+
   @Override
   public int hashCode() {
     int result = upstream.hashCode();

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
@@ -1,8 +1,5 @@
 package com.hubspot.baragon.models;
 
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -11,6 +8,9 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class UpstreamInfo {
@@ -25,6 +25,10 @@ public class UpstreamInfo {
   private final String rackId;
   private final Optional<String> originalPath;
 
+  @Size(max=100)
+  @Pattern(regexp = "^$|[^\\s|]+", message = "cannot contain whitespace, '/', or '|'")
+  private final Optional<String> group;
+
   @JsonCreator
   public static UpstreamInfo fromString(String value) {
     String[] split = value.split("\\|", -1);
@@ -34,27 +38,30 @@ public class UpstreamInfo {
       String upstream = new String(BaseEncoding.base64Url().decode(split[0]), Charsets.UTF_8);
       Optional<String> requestId = split.length > 1 && !split[1].equals("") ? Optional.of(split[1]) : Optional.<String>absent();
       Optional<String> rackId = split.length > 2 && !split[2].equals("") ? Optional.of(split[2]) : Optional.<String>absent();
-      return new UpstreamInfo(upstream, requestId, rackId, Optional.of(value));
+      Optional<String> group = split.length > 3 && !split[3].equals("") ? Optional.of(split[3]) : Optional.<String>absent();
+      return new UpstreamInfo(upstream, requestId, rackId, Optional.of(value), group);
     }
   }
 
   public static UpstreamInfo fromUnEncodedString(String upstream) {
-    return new UpstreamInfo(upstream, Optional.<String>absent(), Optional.<String>absent(), Optional.of(upstream));
+    return new UpstreamInfo(upstream, Optional.<String>absent(), Optional.<String>absent(), Optional.of(upstream), Optional.<String>absent());
   }
 
   public UpstreamInfo (String upstream, Optional<String> requestId, Optional<String> rackId) {
-    this(upstream, requestId, rackId, Optional.<String>absent());
+    this(upstream, requestId, rackId, Optional.<String>absent(), Optional.<String>absent());
   }
 
   @JsonCreator
   public UpstreamInfo(@JsonProperty("upstream") String upstream,
                       @JsonProperty("requestId") Optional<String> requestId,
                       @JsonProperty("rackId") Optional<String> rackId,
-                      @JsonProperty("originalPath") Optional<String> originalPath) {
+                      @JsonProperty("originalPath") Optional<String> originalPath,
+                      @JsonProperty("group") Optional<String> group) {
     this.upstream = upstream;
     this.requestId = requestId.or("");
     this.rackId = rackId.or("");
     this.originalPath = originalPath;
+    this.group = group;
   }
 
   public String getUpstream() {
@@ -74,13 +81,17 @@ public class UpstreamInfo {
     return originalPath;
   }
 
+  public Optional<String> getGroup() {
+    return group;
+  }
+
   @Override
   public String toString() {
     return upstream;
   }
 
   public String toPath() {
-    return String.format("%s|%s|%s", sanitizeUpstream(upstream), requestId, rackId);
+    return String.format("%s|%s|%s|%s", sanitizeUpstream(upstream), requestId, rackId, group);
   }
 
   protected String sanitizeUpstream(String name) {
@@ -110,6 +121,9 @@ public class UpstreamInfo {
     if (!originalPath.equals(that.originalPath)) {
       return false;
     }
+    if (!group.equals(that.group)) {
+      return false;
+    }
 
     return true;
   }
@@ -119,7 +133,8 @@ public class UpstreamInfo {
     int result = upstream.hashCode();
     result = 31 * result + requestId.hashCode();
     result = 31 * result + rackId.hashCode();
-    result = 31 *result + originalPath.hashCode();
+    result = 31 * result + originalPath.hashCode();
+    result = 31 * result + group.hashCode();
     return result;
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/UpstreamInfo.java
@@ -14,6 +14,8 @@ import javax.validation.constraints.Size;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class UpstreamInfo {
+  public static final String DEFAULT_GROUP = "default";
+
   private final String upstream;
 
   @Size(max=250)
@@ -24,7 +26,10 @@ public class UpstreamInfo {
   @Pattern(regexp = "^$|[^\\s|]+", message = "cannot contain whitespace, '/', or '|'")
   private final String rackId;
   private final Optional<String> originalPath;
-  private final Optional<String> group;
+
+  @Size(max=100)
+  @Pattern(regexp = "^$|[^\\s|]+", message = "cannot contain whitespace, '/', or '|'")
+  private final String group;
 
   @JsonCreator
   public static UpstreamInfo fromString(String value) {
@@ -62,7 +67,7 @@ public class UpstreamInfo {
     this.requestId = requestId.or("");
     this.rackId = rackId.or("");
     this.originalPath = originalPath;
-    this.group = group;
+    this.group = group.or(DEFAULT_GROUP);
   }
 
   public String getUpstream() {
@@ -82,7 +87,7 @@ public class UpstreamInfo {
     return originalPath;
   }
 
-  public Optional<String> getGroup() {
+  public String getGroup() {
     return group;
   }
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -97,9 +97,8 @@ public class BaragonStateDatastore extends AbstractDataStore {
       createNode(SERVICES_FORMAT);
     }
 
-    Collection<UpstreamInfo> currentUpstreams = getUpstreams(request.getLoadBalancerService().getServiceId());
-
     String serviceId = request.getLoadBalancerService().getServiceId();
+    Collection<UpstreamInfo> currentUpstreams = getUpstreams(serviceId);
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransactionFinal transaction;
     if (nodeExists(servicePath)) {
@@ -110,7 +109,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
 
     List<String> pathsToDelete = new ArrayList<>();
     if (!request.getReplaceUpstreams().isEmpty()) {
-      for (UpstreamInfo upstreamInfo : getUpstreams(serviceId)) {
+      for (UpstreamInfo upstreamInfo : currentUpstreams) {
         String removePath = String.format(UPSTREAM_FORMAT, serviceId, getRemovePath(currentUpstreams, upstreamInfo));
         if (nodeExists(removePath)) {
           pathsToDelete.add(removePath);
@@ -119,15 +118,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
       }
       for (UpstreamInfo upstreamInfo : request.getReplaceUpstreams()) {
         String addPath = String.format(UPSTREAM_FORMAT, serviceId, upstreamInfo.toPath());
-        List<String> matchingUpstreamPaths = matchingUpstreamPaths(currentUpstreams, upstreamInfo);
-        for (String matchingPath : matchingUpstreamPaths) {
-          String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
-          if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath)) {
-            pathsToDelete.add(fullPath);
-            transaction.delete().forPath(fullPath);
-          }
-        }
-        if (!nodeExists(addPath)) {
+        if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {
           transaction.create().forPath(addPath).and();
         }
       }
@@ -161,7 +152,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
   private List<String> matchingUpstreamPaths(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toAdd) {
     List<String> matchingPaths = new ArrayList<>();
     for (UpstreamInfo upstreamInfo : currentUpstreams) {
-      if (upstreamInfo.getUpstream().equals(toAdd.getUpstream())) {
+      if (upstreamInfo.sameAs(toAdd)) {
         matchingPaths.add(upstreamInfo.getOriginalPath().or(upstreamInfo.getUpstream()));
       }
     }
@@ -170,7 +161,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
 
   private String getRemovePath(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toRemove) {
     for (UpstreamInfo upstreamInfo : currentUpstreams) {
-      if (upstreamInfo.getUpstream().equals(toRemove.getUpstream())) {
+      if (upstreamInfo.sameAs(toRemove)) {
         return upstreamInfo.getOriginalPath().or(upstreamInfo.toPath());
       }
     }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -138,7 +138,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
           if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath) && !fullPath.equals(addPath)) {
             LOG.info(String.format("Deleting %s", fullPath));
             pathsToDelete.add(fullPath);
-            transaction.delete().forPath(fullPath);
+            transaction.delete().forPath(fullPath).and();
           }
         }
         if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -1,21 +1,5 @@
 package com.hubspot.baragon.data;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
-import org.apache.curator.utils.ZKPaths;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
@@ -31,6 +15,21 @@ import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.baragon.utils.ZkParallelFetcher;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 @Singleton
 public class BaragonStateDatastore extends AbstractDataStore {
@@ -152,7 +151,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
   private List<String> matchingUpstreamPaths(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toAdd) {
     List<String> matchingPaths = new ArrayList<>();
     for (UpstreamInfo upstreamInfo : currentUpstreams) {
-      if (upstreamInfo.sameAs(toAdd)) {
+      if (UpstreamInfo.upstreamAndGroupMatches(upstreamInfo, toAdd)) {
         matchingPaths.add(upstreamInfo.getOriginalPath().or(upstreamInfo.getUpstream()));
       }
     }
@@ -161,7 +160,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
 
   private String getRemovePath(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toRemove) {
     for (UpstreamInfo upstreamInfo : currentUpstreams) {
-      if (upstreamInfo.sameAs(toRemove)) {
+      if (UpstreamInfo.upstreamAndGroupMatches(upstreamInfo, toRemove)) {
         return upstreamInfo.getOriginalPath().or(upstreamInfo.toPath());
       }
     }

--- a/BaragonUI/app/templates/serviceDetail.hbs
+++ b/BaragonUI/app/templates/serviceDetail.hbs
@@ -124,7 +124,7 @@
                     {{#each service.splitUpstreams}}
                         <div class="col-md-6">
                             {{#each this}}
-                                <h4>{{upstream}} {{#if rackId}}({{ rackId }}){{/if}}{{#if ../../config.allowEdit}}<a class="pull-left" data-action="removeUpstream"><span class="glyphicon glyphicon-remove inactive" data-upstream="{{ upstream }}"></span></a>{{/if}}</h4>
+                                <h4>{{upstream}} {{#if rackId}}({{ rackId }}){{/if}}{{#if group}}({{{ group }}}){{/if}}{{#if ../../config.allowEdit}}<a class="pull-left" data-action="removeUpstream"><span class="glyphicon glyphicon-remove inactive" data-upstream="{{ upstream }}"></span></a>{{/if}}</h4>
                             {{/each}}
                         </div>
                     {{/each}}


### PR DESCRIPTION
- Adds optional `group` field to `UpstreamInfo` class (defaults to `DEFAULT` if absent)
- Adds additional `upstreamGroups` field to `ServiceContext` class (the handlebars templates use this). Upstreams without a `group` value are added to the `default` group.
- The original `upstreams` list in `ServiceContext` is not affected -- this will contain *all* upstreams.

@ssalinas 