### PR TITLE
add more logging around removal of upstreams

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -129,7 +129,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
           LOG.info("Deleting {}", removePath);
           transaction.delete().forPath(removePath).and();
         } else {
-          LOG.warn("No upstream node found to delete for {}, calculated path {}, current upstream nodes are {}", upstreamInfo, removePath, currentUpstreams);
+          LOG.warn("No upstream node found to delete for {}, calculated path to remove was {}, current upstream nodes are {}", upstreamInfo, removePath, currentUpstreams);
         }
       }
       for (UpstreamInfo upstreamInfo : request.getAddUpstreams()) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -126,7 +126,10 @@ public class BaragonStateDatastore extends AbstractDataStore {
         String removePath = String.format(UPSTREAM_FORMAT, serviceId, getRemovePath(currentUpstreams, upstreamInfo));
         if (nodeExists(removePath)) {
           pathsToDelete.add(removePath);
+          LOG.info("Deleting {}", removePath);
           transaction.delete().forPath(removePath).and();
+        } else {
+          LOG.warn("No upstream node found to delete for {}, calculated path {}, current upstream nodes are {}", upstreamInfo, removePath, currentUpstreams);
         }
       }
       for (UpstreamInfo upstreamInfo : request.getAddUpstreams()) {
@@ -135,7 +138,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
         for (String matchingPath : matchingUpstreamPaths) {
           String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
           if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath) && !fullPath.equals(addPath)) {
-            LOG.info(String.format("Deleting %s", fullPath));
+            LOG.info("Deleting {}", fullPath);
             pathsToDelete.add(fullPath);
             transaction.delete().forPath(fullPath).and();
           }


### PR DESCRIPTION
@tpetr , I wasn't able to completely diagnose the odd extra upstream we found with the current logs. Going to add these statements in to hopefully help in case it happens again. Guessing what happened is we hit the case for the `else` statement I added, meaning we calculated a path that we thought we needed to remove, but it was the wrong one (didn't actually exist), so we keep going. That `warn` statement should give us everything we need in order to debug if we see it again.