### PR TITLE
Batch requests

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -169,7 +169,7 @@ public class BaragonAgentServiceModule extends AbstractModule {
     final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
     final String agentId = String.format("%s:%s", hostname, httpPort);
 
-    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getExtraAgentData());
+    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getExtraAgentData(), true);
   }
 
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
@@ -118,7 +118,7 @@ public class FilesystemConfigHelper {
     LOG.info(String.format("Apply finished for %s", service.getServiceId()));
   }
 
-  public void apply(ServiceContext context, Optional<BaragonService> maybeOldService, boolean revertOnFailure, boolean noReload, boolean noValidate) throws InvalidConfigException, LbAdapterExecuteException, IOException, MissingTemplateException, InterruptedException, LockTimeoutException {
+  public void apply(ServiceContext context, Optional<BaragonService> maybeOldService, boolean revertOnFailure, boolean noReload, boolean noValidate, boolean delayReload) throws InvalidConfigException, LbAdapterExecuteException, IOException, MissingTemplateException, InterruptedException, LockTimeoutException {
     final BaragonService service = context.getService();
     final BaragonService oldService = maybeOldService.or(service);
 
@@ -163,10 +163,10 @@ public class FilesystemConfigHelper {
       } else {
         LOG.debug("Not validating configs due to 'noValidate' specified in request");
       }
-      if (!noReload) {
+      if (!noReload && !delayReload) {
         adapter.reloadConfigs();
       } else {
-        LOG.debug("Not reloading configs due to 'noReload' specified in request");
+        LOG.debug("Not reloading configs: {}", noReload ? "'noReload' specified in request" : "Will reload at end of request batch");
       }
     } catch (Exception e) {
       LOG.error(String.format("Caught exception while writing configs for %s, reverting to backups!", service.getServiceId()), e);
@@ -192,7 +192,7 @@ public class FilesystemConfigHelper {
     LOG.info(String.format("Apply finished for %s", service.getServiceId()));
   }
 
-  public void delete(BaragonService service, Optional<BaragonService> maybeOldService, boolean noReload, boolean noValidate) throws InvalidConfigException, LbAdapterExecuteException, IOException, MissingTemplateException, InterruptedException, LockTimeoutException {
+  public void delete(BaragonService service, Optional<BaragonService> maybeOldService, boolean noReload, boolean noValidate, boolean delayReload) throws InvalidConfigException, LbAdapterExecuteException, IOException, MissingTemplateException, InterruptedException, LockTimeoutException {
     final boolean oldServiceExists = (maybeOldService.isPresent() && configsExist(maybeOldService.get()));
     final boolean previousConfigsExist = configsExist(service);
 
@@ -213,10 +213,10 @@ public class FilesystemConfigHelper {
       } else {
         LOG.debug("Not validating configs due to 'noValidate' specified in request");
       }
-      if (!noReload) {
+      if (!noReload && !delayReload) {
         adapter.reloadConfigs();
       } else {
-        LOG.debug("Not reloading configs due to 'noReload' specified in request");
+        LOG.debug("Not reloading configs: {}", noReload ? "'noReload' specified in request" : "Will reload at end of request batch");
       }
     } catch (Exception e) {
       LOG.error(String.format("Caught exception while deleting configs for %s, reverting to backups!", service.getServiceId()), e);

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -1,6 +1,7 @@
 package com.hubspot.baragon.agent.managers;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -12,8 +13,10 @@ import com.hubspot.baragon.data.BaragonRequestDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.exceptions.LockTimeoutException;
 import com.hubspot.baragon.exceptions.MissingTemplateException;
+import com.hubspot.baragon.models.AgentBatchResponseItem;
 import com.hubspot.baragon.models.BaragonAgentState;
 import com.hubspot.baragon.models.BaragonRequest;
+import com.hubspot.baragon.models.BaragonRequestBatchItem;
 import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.RequestAction;
 import com.hubspot.baragon.models.ServiceContext;
@@ -23,8 +26,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.Response;
 
@@ -62,7 +68,38 @@ public class AgentRequestManager {
     this.agentLockTimeoutMs = agentLockTimeoutMs;
   }
 
-  public Response processRequest(String requestId, Optional<RequestAction> maybeAction) throws InterruptedException {
+  public Set<AgentBatchResponseItem> processRequests(Set<BaragonRequestBatchItem> batch) throws InterruptedException {
+    Set<AgentBatchResponseItem> responses = Sets.newHashSet();
+    int i = 0;
+    for (BaragonRequestBatchItem item : batch) {
+      boolean isLast = i == batch.size() - 1;
+      responses.add(getResponseItem(processRequest(item.getRequestId(), actionForBatchItem(item), !isLast), item));
+      i++;
+    }
+    return responses;
+  }
+
+  private AgentBatchResponseItem getResponseItem(Response httpResponse, BaragonRequestBatchItem item) {
+    Optional<String> maybeMessage = httpResponse.getEntity() != null ? Optional.of(httpResponse.getEntity().toString()) : Optional.<String>absent();
+    return new AgentBatchResponseItem(item.getRequestId(), httpResponse.getStatus(), maybeMessage, item.getRequestType());
+  }
+
+  private Optional<RequestAction> actionForBatchItem(BaragonRequestBatchItem item) {
+    if (item.getRequestAction().isPresent()) {
+      return item.getRequestAction();
+    } else {
+      switch (item.getRequestType()) {
+        case REVERT:
+        case CANCEL:
+          return Optional.of(RequestAction.REVERT);
+        case APPLY:
+        default:
+          return Optional.of(RequestAction.UPDATE);
+      }
+    }
+  }
+
+  public Response processRequest(String requestId, Optional<RequestAction> maybeAction, boolean delayReload) throws InterruptedException {
     final Optional<BaragonRequest> maybeRequest = requestDatastore.getRequest(requestId);
     if (!maybeRequest.isPresent()) {
       return Response.status(Response.Status.NOT_FOUND).entity(String.format("Request %s does not exist", requestId)).build();
@@ -76,13 +113,13 @@ public class AgentRequestManager {
       LOG.info(String.format("Received request to %s with id %s", action, requestId));
       switch (action) {
         case DELETE:
-          return delete(request, maybeOldService);
+          return delete(request, maybeOldService, delayReload);
         case RELOAD:
-          return reload(request);
+          return reload(request, delayReload);
         case REVERT:
-          return revert(request, maybeOldService);
+          return revert(request, maybeOldService, delayReload);
         default:
-          return apply(request, maybeOldService);
+          return apply(request, maybeOldService, delayReload);
       }
     } catch (LockTimeoutException e) {
       LOG.warn(String.format("Couldn't acquire agent lock for %s in %s ms", requestId, agentLockTimeoutMs), e);
@@ -96,15 +133,17 @@ public class AgentRequestManager {
     }
   }
 
-  private Response reload(BaragonRequest request) throws Exception {
-    configHelper.checkAndReload();
+  private Response reload(BaragonRequest request, boolean delayReload) throws Exception {
+    if (!delayReload) {
+      configHelper.checkAndReload();
+    }
     mostRecentRequestId.set(request.getLoadBalancerRequestId());
     return Response.ok().build();
   }
 
-  private Response delete(BaragonRequest request, Optional<BaragonService> maybeOldService) throws Exception {
+  private Response delete(BaragonRequest request, Optional<BaragonService> maybeOldService, boolean delayReload) throws Exception {
     try {
-      configHelper.delete(request.getLoadBalancerService(), maybeOldService, request.isNoReload(), request.isNoValidate());
+      configHelper.delete(request.getLoadBalancerService(), maybeOldService, request.isNoReload(), request.isNoValidate(), delayReload);
       mostRecentRequestId.set(request.getLoadBalancerRequestId());
       return Response.ok().build();
     } catch (Exception e) {
@@ -112,11 +151,11 @@ public class AgentRequestManager {
     }
   }
 
-  private Response apply(BaragonRequest request, Optional<BaragonService> maybeOldService) throws Exception {
+  private Response apply(BaragonRequest request, Optional<BaragonService> maybeOldService, boolean delayReload) throws Exception {
     final ServiceContext update = getApplyContext(request);
     triggerTesting();
     try {
-      configHelper.apply(update, maybeOldService, true, request.isNoReload(), request.isNoValidate());
+      configHelper.apply(update, maybeOldService, true, request.isNoReload(), request.isNoValidate(), delayReload);
     } catch (Exception e) {
       return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
@@ -124,7 +163,7 @@ public class AgentRequestManager {
     return Response.ok().build();
   }
 
-  private Response revert(BaragonRequest request, Optional<BaragonService> maybeOldService) throws Exception {
+  private Response revert(BaragonRequest request, Optional<BaragonService> maybeOldService, boolean delayReload) throws Exception {
     final ServiceContext update;
     if (movedOffLoadBalancer(maybeOldService)) {
       update = new ServiceContext(request.getLoadBalancerService(), Collections.<UpstreamInfo>emptyList(), System.currentTimeMillis(), false);
@@ -136,7 +175,7 @@ public class AgentRequestManager {
 
     LOG.info(String.format("Reverting to %s", update));
     try {
-      configHelper.apply(update, Optional.<BaragonService>absent(), false, request.isNoReload(), request.isNoValidate());
+      configHelper.apply(update, Optional.<BaragonService>absent(), false, request.isNoReload(), request.isNoValidate(), delayReload);
     } catch (MissingTemplateException e) {
       if (serviceDidNotPreviouslyExist(maybeOldService)) {
         return Response.ok().build();

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/BatchRequestResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/BatchRequestResource.java
@@ -1,0 +1,35 @@
+package com.hubspot.baragon.agent.resources;
+
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.hubspot.baragon.agent.managers.AgentRequestManager;
+import com.hubspot.baragon.models.AgentBatchResponseItem;
+import com.hubspot.baragon.models.BaragonRequestBatchItem;
+
+@Path("/batch")
+@Produces(MediaType.APPLICATION_JSON)
+public class BatchRequestResource {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchRequestResource.class);
+  private final AgentRequestManager agentRequestManager;
+
+  @Inject
+  public BatchRequestResource(AgentRequestManager agentRequestManager) {
+    this.agentRequestManager = agentRequestManager;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Set<AgentBatchResponseItem> apply(Set<BaragonRequestBatchItem> batch) throws InterruptedException {
+    return agentRequestManager.processRequests(batch);
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
@@ -11,37 +11,29 @@ import javax.ws.rs.core.Response;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import com.hubspot.baragon.agent.config.LoadBalancerConfiguration;
 import com.hubspot.baragon.agent.managers.AgentRequestManager;
 import com.hubspot.baragon.models.RequestAction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @Path("/request/{requestId}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class RequestResource {
-  private static final Logger LOG = LoggerFactory.getLogger(RequestResource.class);
-
   private final AgentRequestManager agentRequestManager;
-  private final LoadBalancerConfiguration loadBalancerConfiguration;
 
   @Inject
-  public RequestResource(AgentRequestManager agentRequestManager,
-                         LoadBalancerConfiguration loadBalancerConfiguration) {
+  public RequestResource(AgentRequestManager agentRequestManager) {
     this.agentRequestManager = agentRequestManager;
-    this.loadBalancerConfiguration = loadBalancerConfiguration;
   }
 
   @POST
   public Response apply(@PathParam("requestId") String requestId) throws InterruptedException {
-    return agentRequestManager.processRequest(requestId, Optional.<RequestAction>absent());
+    return agentRequestManager.processRequest(requestId, Optional.<RequestAction>absent(), false);
   }
 
   @DELETE
   public Response revert(@PathParam("requestId") String requestId) throws InterruptedException {
-    return agentRequestManager.processRequest(requestId, Optional.of(RequestAction.REVERT));
+    return agentRequestManager.processRequest(requestId, Optional.of(RequestAction.REVERT), false);
   }
 
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentBatchResponseItem.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentBatchResponseItem.java
@@ -1,0 +1,70 @@
+package com.hubspot.baragon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+
+public class AgentBatchResponseItem {
+  private final String requestId;
+  private final int statusCode;
+  private final Optional<String> message;
+  private final AgentRequestType requestType;
+
+  @JsonCreator
+  public AgentBatchResponseItem(@JsonProperty("requestId") String requestId,
+                                @JsonProperty("statusCode") int statusCode,
+                                @JsonProperty("message") Optional<String> message,
+                                @JsonProperty("requestType") AgentRequestType requestType) {
+    this.requestId = requestId;
+    this.statusCode = statusCode;
+    this.message = message;
+    this.requestType = requestType;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public Optional<String> getMessage() {
+    return message;
+  }
+
+  public AgentRequestType getRequestType() {
+    return requestType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AgentBatchResponseItem that = (AgentBatchResponseItem) o;
+    return statusCode == that.statusCode &&
+      Objects.equal(requestId, that.requestId) &&
+      Objects.equal(message, that.message) &&
+      requestType == that.requestType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(requestId, statusCode, message, requestType);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("requestId", requestId)
+      .add("statusCode", statusCode)
+      .add("message", message)
+      .add("requestType", requestType)
+      .toString();
+  }
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -22,6 +22,7 @@ public class BaragonAgentMetadata {
   private final String agentId;
   private final BaragonAgentEc2Metadata ec2;
   private final Map<String, String> extraAgentData;
+  private final boolean batchEnabled;
 
   @JsonCreator
   public static BaragonAgentMetadata fromString(String value) {
@@ -31,7 +32,7 @@ public class BaragonAgentMetadata {
       throw new InvalidAgentMetadataStringException(value);
     }
 
-    return new BaragonAgentMetadata(value, matcher.group(1), Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap());
+    return new BaragonAgentMetadata(value, matcher.group(1), Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), false);
   }
 
   @JsonCreator
@@ -39,12 +40,14 @@ public class BaragonAgentMetadata {
                               @JsonProperty("agentId") String agentId,
                               @JsonProperty("domain") Optional<String> domain,
                               @JsonProperty("ec2") BaragonAgentEc2Metadata ec2,
-                              @JsonProperty("extraAgentData") Map<String, String> extraAgentData) {
+                              @JsonProperty("extraAgentData") Map<String, String> extraAgentData,
+                              @JsonProperty("batchEnabled") boolean batchEnabled) {
     this.baseAgentUri = baseAgentUri;
     this.domain = domain;
     this.agentId = agentId;
     this.ec2 = ec2;
     this.extraAgentData = Objects.firstNonNull(extraAgentData, Collections.<String, String>emptyMap());
+    this.batchEnabled = Objects.firstNonNull(batchEnabled, false);
   }
 
   public String getBaseAgentUri() {
@@ -68,6 +71,10 @@ public class BaragonAgentMetadata {
     return extraAgentData;
   }
 
+  public boolean isBatchEnabled() {
+    return batchEnabled;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -76,46 +83,30 @@ public class BaragonAgentMetadata {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    BaragonAgentMetadata metadata = (BaragonAgentMetadata) o;
-
-    if (agentId != null ? !agentId.equals(metadata.agentId) : metadata.agentId != null) {
-      return false;
-    }
-    if (!baseAgentUri.equals(metadata.baseAgentUri)) {
-      return false;
-    }
-    if (!domain.equals(metadata.domain)) {
-      return false;
-    }
-    if (!ec2.equals(metadata.ec2)) {
-      return false;
-    }
-    if (!extraAgentData.equals(metadata.extraAgentData)) {
-      return false;
-    }
-
-    return true;
+    BaragonAgentMetadata that = (BaragonAgentMetadata) o;
+    return batchEnabled == that.batchEnabled &&
+      Objects.equal(baseAgentUri, that.baseAgentUri) &&
+      Objects.equal(domain, that.domain) &&
+      Objects.equal(agentId, that.agentId) &&
+      Objects.equal(ec2, that.ec2) &&
+      Objects.equal(extraAgentData, that.extraAgentData) &&
+      Objects.equal(batchEnabled, batchEnabled);
   }
 
   @Override
   public int hashCode() {
-    int result = baseAgentUri.hashCode();
-    result = 31 * result + domain.hashCode();
-    result = 31 * result + (agentId != null ? agentId.hashCode() : 0);
-    result = 31 * result + (ec2 != null ? ec2.hashCode() : 0);
-    result = 31 * result + extraAgentData.hashCode();
-    return result;
+    return Objects.hashCode(baseAgentUri, domain, agentId, ec2, extraAgentData, batchEnabled);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-            .add("baseAgentUri", baseAgentUri)
-            .add("domain", domain)
-            .add("agentId", agentId)
-            .add("ec2", ec2)
-            .add("extraAgentData", extraAgentData)
-            .toString();
+      .add("baseAgentUri", baseAgentUri)
+      .add("domain", domain)
+      .add("agentId", agentId)
+      .add("ec2", ec2)
+      .add("extraAgentData", extraAgentData)
+      .add("batchEnabled", batchEnabled)
+      .toString();
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
@@ -13,7 +13,7 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
   private long lastSeenAt;
 
   public static BaragonKnownAgentMetadata fromAgentMetadata(BaragonAgentMetadata agentMetadata, long lastSeenAt) {
-    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getExtraAgentData(), lastSeenAt);
+    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getExtraAgentData(), agentMetadata.isBatchEnabled(), lastSeenAt);
   }
 
   @JsonCreator
@@ -22,8 +22,9 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
                                    @JsonProperty("domain") Optional<String> domain,
                                    @JsonProperty("ec2") BaragonAgentEc2Metadata ec2,
                                    @JsonProperty("extraAgentData")Map<String, String> extraAgentData,
+                                   @JsonProperty("batchEnabled") boolean batchEnabled,
                                    @JsonProperty("lastSeenAt") long lastSeenAt) {
-    super(baseAgentUri, agentId, domain, ec2, extraAgentData);
+    super(baseAgentUri, agentId, domain, ec2, extraAgentData, batchEnabled);
     this.lastSeenAt = lastSeenAt;
   }
 

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestBatchItem.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestBatchItem.java
@@ -1,0 +1,61 @@
+package com.hubspot.baragon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+
+public class BaragonRequestBatchItem {
+  private final String requestId;
+  private final Optional<RequestAction> requestAction;
+  private final AgentRequestType requestType;
+
+  @JsonCreator
+  public BaragonRequestBatchItem(@JsonProperty("requestId") String requestId,
+                                 @JsonProperty("requestAction") Optional<RequestAction> requestAction,
+                                 @JsonProperty("requestType") AgentRequestType requestType) {
+    this.requestId = requestId;
+    this.requestAction = requestAction;
+    this.requestType = requestType;
+  }
+
+  public String getRequestId() {
+    return requestId;
+  }
+
+  public Optional<RequestAction> getRequestAction() {
+    return requestAction;
+  }
+
+  public AgentRequestType getRequestType() {
+    return requestType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BaragonRequestBatchItem that = (BaragonRequestBatchItem) o;
+    return Objects.equal(requestId, that.requestId) &&
+      Objects.equal(requestAction, that.requestAction) &&
+      requestType == that.requestType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(requestId, requestAction, requestType);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("requestId", requestId)
+      .add("requestAction", requestAction)
+      .add("requestType", requestType)
+      .toString();
+  }
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/InternalRequestStates.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/InternalRequestStates.java
@@ -1,17 +1,27 @@
 package com.hubspot.baragon.models;
 
 public enum InternalRequestStates {
-  PENDING,
-  INVALID_REQUEST_NOOP,
-  SEND_APPLY_REQUESTS,
-  CHECK_APPLY_RESPONSES,
-  COMPLETED,
-  FAILED_SEND_REVERT_REQUESTS,
-  FAILED_CHECK_REVERT_RESPONSES,
-  FAILED_REVERTED,
-  FAILED_REVERT_FAILED,
-  CANCELLED_SEND_REVERT_REQUESTS,
-  CANCELLED_CHECK_REVERT_RESPONSES,
-  CANCELLED,
-  FAILED_CANCEL_FAILED
+  PENDING(false),
+  INVALID_REQUEST_NOOP(false),
+  SEND_APPLY_REQUESTS(true),
+  CHECK_APPLY_RESPONSES(false),
+  COMPLETED(false),
+  FAILED_SEND_REVERT_REQUESTS(true),
+  FAILED_CHECK_REVERT_RESPONSES(false),
+  FAILED_REVERTED(false),
+  FAILED_REVERT_FAILED(false),
+  CANCELLED_SEND_REVERT_REQUESTS(true),
+  CANCELLED_CHECK_REVERT_RESPONSES(false),
+  CANCELLED(false),
+  FAILED_CANCEL_FAILED(false);
+
+  private final boolean requireAgentRequest;
+
+  InternalRequestStates(boolean requireAgentRequest) {
+     this.requireAgentRequest = requireAgentRequest;
+  }
+
+  public boolean isRequireAgentRequest() {
+    return requireAgentRequest;
+  }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestWithState.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestWithState.java
@@ -1,0 +1,60 @@
+package com.hubspot.baragon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+public class QueuedRequestWithState {
+  private final QueuedRequestId queuedRequestId;
+  private final BaragonRequest request;
+  private final InternalRequestStates currentState;
+
+  @JsonCreator
+  public QueuedRequestWithState(@JsonProperty("queuedRequestId") QueuedRequestId queuedRequestId,
+                                @JsonProperty("request") BaragonRequest request,
+                                @JsonProperty("currentState") InternalRequestStates currentState) {
+    this.queuedRequestId = queuedRequestId;
+    this.request = request;
+    this.currentState = currentState;
+  }
+
+  public QueuedRequestId getQueuedRequestId() {
+    return queuedRequestId;
+  }
+
+  public BaragonRequest getRequest() {
+    return request;
+  }
+
+  public InternalRequestStates getCurrentState() {
+    return currentState;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueuedRequestWithState that = (QueuedRequestWithState) o;
+    return Objects.equal(queuedRequestId, that.queuedRequestId) &&
+      Objects.equal(request, that.request) &&
+      currentState == that.currentState;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(queuedRequestId, request, currentState);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("queuedRequestId", queuedRequestId)
+      .add("request", request)
+      .add("currentState", currentState)
+      .toString();
+  }
+}

--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -28,6 +28,7 @@ import org.apache.curator.framework.state.ConnectionState;
 
 public class BaragonDataModule extends AbstractModule {
   public static final String BARAGON_AGENT_REQUEST_URI_FORMAT = "baragon.agent.request.uri.format";
+  public static final String BARAGON_AGENT_BATCH_REQUEST_URI_FORMAT = "baragon.agent.batch.request.uri.format";
   public static final String BARAGON_AGENT_MAX_ATTEMPTS = "baragon.agent.maxAttempts";
   public static final String BARAGON_AGENT_REQUEST_TIMEOUT_MS = "baragon.agent.requestTimeoutMs";
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -2,8 +2,6 @@ package com.hubspot.baragon.data;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -2,6 +2,8 @@ package com.hubspot.baragon.data;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -112,6 +112,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
     </dependency>
@@ -162,6 +166,10 @@
     <dependency>
       <groupId>net.kencochrane.raven</groupId>
       <artifactId>raven</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jukito</groupId>

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -81,6 +81,12 @@ public class BaragonServiceModule extends AbstractModule {
   }
 
   @Provides
+  @Named(BaragonDataModule.BARAGON_AGENT_BATCH_REQUEST_URI_FORMAT)
+  public String provideAgentBatchUriFormat(BaragonConfiguration configuration) {
+    return configuration.getAgentBatchRequestUriFormat();
+  }
+
+  @Provides
   @Named(BaragonDataModule.BARAGON_AGENT_MAX_ATTEMPTS)
   public Integer provideAgentMaxAttempts(BaragonConfiguration configuration) {
     return configuration.getAgentMaxAttempts();

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -19,6 +19,7 @@ import io.dropwizard.Configuration;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BaragonConfiguration extends Configuration {
   public static final String DEFAULT_AGENT_REQUEST_URI_FORMAT = "%s/request/%s";
+  public static final String DEFAULT_AGENT_BATCH_REQUEST_URI_FORMAT = "%s/batch";
 
   @JsonProperty("zookeeper")
   @NotNull
@@ -42,6 +43,10 @@ public class BaragonConfiguration extends Configuration {
   @JsonProperty("agentRequestUriFormat")
   @NotEmpty
   private String agentRequestUriFormat = DEFAULT_AGENT_REQUEST_URI_FORMAT;
+
+  @JsonProperty("agentBatchRequestUriFormat")
+  @NotEmpty
+  private String agentBatchRequestUriFormat = DEFAULT_AGENT_BATCH_REQUEST_URI_FORMAT;
 
   @JsonProperty("agentMaxAttempts")
   @Min(1)
@@ -105,6 +110,14 @@ public class BaragonConfiguration extends Configuration {
 
   public String getAgentRequestUriFormat() {
     return agentRequestUriFormat;
+  }
+
+  public void setAgentBatchRequestUriFormat(String agentBatchRequestUriFormat) {
+    this.agentBatchRequestUriFormat = agentBatchRequestUriFormat;
+  }
+
+  public String getAgentBatchRequestUriFormat() {
+    return agentBatchRequestUriFormat;
   }
 
   public void setAgentRequestUriFormat(String agentRequestUriFormat) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonWorkerConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonWorkerConfiguration.java
@@ -15,6 +15,9 @@ public class BaragonWorkerConfiguration {
   @Min(0)
   private int initialDelayMs = 0;
 
+  @Min(1)
+  private int maxBatchSize = 50;
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -37,5 +40,13 @@ public class BaragonWorkerConfiguration {
 
   public void setInitialDelayMs(int initialDelayMs) {
     this.initialDelayMs = initialDelayMs;
+  }
+
+  public int getMaxBatchSize() {
+    return maxBatchSize;
+  }
+
+  public void setMaxBatchSize(int maxBatchSize) {
+    this.maxBatchSize = maxBatchSize;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/AgentManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/AgentManager.java
@@ -2,11 +2,18 @@ package com.hubspot.baragon.service.managers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
@@ -17,6 +24,7 @@ import com.hubspot.baragon.BaragonDataModule;
 import com.hubspot.baragon.data.BaragonAgentResponseDatastore;
 import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.models.AgentBatchResponseItem;
 import com.hubspot.baragon.models.AgentRequestType;
 import com.hubspot.baragon.models.AgentRequestsStatus;
 import com.hubspot.baragon.models.AgentResponse;
@@ -24,7 +32,11 @@ import com.hubspot.baragon.models.AgentResponseId;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
 import com.hubspot.baragon.models.BaragonRequest;
+import com.hubspot.baragon.models.BaragonRequestBatchItem;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.InternalRequestStates;
+import com.hubspot.baragon.models.InternalStatesMap;
+import com.hubspot.baragon.models.QueuedRequestWithState;
 import com.hubspot.baragon.models.RequestAction;
 import com.hubspot.baragon.service.BaragonServiceModule;
 import com.hubspot.baragon.service.config.BaragonConfiguration;
@@ -44,18 +56,22 @@ public class AgentManager {
   private final BaragonAgentResponseDatastore agentResponseDatastore;
   private final AsyncHttpClient asyncHttpClient;
   private final String baragonAgentRequestUriFormat;
+  private final String baragonAgentBatchRequestUriFormat;
   private final Integer baragonAgentMaxAttempts;
   private final Optional<String> baragonAuthKey;
   private final Long baragonAgentRequestTimeout;
   private final BaragonConfiguration configuration;
+  private final ObjectMapper objectMapper;
 
   @Inject
   public AgentManager(BaragonLoadBalancerDatastore loadBalancerDatastore,
                       BaragonStateDatastore stateDatastore,
                       BaragonAgentResponseDatastore agentResponseDatastore,
                       BaragonConfiguration configuration,
+                      ObjectMapper objectMapper,
                       @Named(BaragonServiceModule.BARAGON_SERVICE_HTTP_CLIENT) AsyncHttpClient asyncHttpClient,
                       @Named(BaragonDataModule.BARAGON_AGENT_REQUEST_URI_FORMAT) String baragonAgentRequestUriFormat,
+                      @Named(BaragonDataModule.BARAGON_AGENT_BATCH_REQUEST_URI_FORMAT) String baragonAgentBatchRequestUriFormat,
                       @Named(BaragonDataModule.BARAGON_AGENT_MAX_ATTEMPTS) Integer baragonAgentMaxAttempts,
                       @Named(BaragonDataModule.BARAGON_AUTH_KEY) Optional<String> baragonAuthKey,
                       @Named(BaragonDataModule.BARAGON_AGENT_REQUEST_TIMEOUT_MS) Long baragonAgentRequestTimeout) {
@@ -63,8 +79,10 @@ public class AgentManager {
     this.stateDatastore = stateDatastore;
     this.agentResponseDatastore = agentResponseDatastore;
     this.configuration = configuration;
+    this.objectMapper = objectMapper;
     this.asyncHttpClient = asyncHttpClient;
     this.baragonAgentRequestUriFormat = baragonAgentRequestUriFormat;
+    this.baragonAgentBatchRequestUriFormat = baragonAgentBatchRequestUriFormat;
     this.baragonAgentMaxAttempts = baragonAgentMaxAttempts;
     this.baragonAuthKey = baragonAuthKey;
     this.baragonAgentRequestTimeout = baragonAgentRequestTimeout;
@@ -91,61 +109,166 @@ public class AgentManager {
     return builder;
   }
 
-  public void sendRequests(final BaragonRequest request, final AgentRequestType requestType) {
-    final Optional<BaragonService> maybeOriginalService = stateDatastore.getService(request.getLoadBalancerService().getServiceId());
+  private AsyncHttpClient.BoundRequestBuilder buildAgentBatchRequest(String url, Set<BaragonRequestBatchItem> batch) throws JsonProcessingException {
+    final BoundRequestBuilder builder = asyncHttpClient.preparePost(url);
+    if (baragonAuthKey.isPresent()) {
+      builder.addQueryParameter("authkey", baragonAuthKey.get());
+    }
+    builder.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+    builder.setBody(objectMapper.writeValueAsBytes(batch));
+    return builder;
+  }
 
-    final Set<String> loadBalancerGroupsToUpdate = Sets.newHashSet(request.getLoadBalancerService().getLoadBalancerGroups());
+  public Map<QueuedRequestWithState, InternalRequestStates> sendRequests(final Set<QueuedRequestWithState> queuedRequestsWithState) {
+    Map<QueuedRequestWithState, InternalRequestStates> results = new HashMap<>();
 
-    if (maybeOriginalService.isPresent()) {
-      loadBalancerGroupsToUpdate.addAll(maybeOriginalService.get().getLoadBalancerGroups());
+    Map<String, Set<BaragonRequestBatchItem>> requestsByGroup = new HashMap<>();
+
+    for (QueuedRequestWithState queuedRequestWithState : queuedRequestsWithState) {
+      final BaragonRequest request = queuedRequestWithState.getRequest();
+      final Optional<BaragonService> maybeOriginalService = stateDatastore.getService(request.getLoadBalancerService().getServiceId());
+      final Set<String> loadBalancerGroupsToUpdate = Sets.newHashSet(request.getLoadBalancerService().getLoadBalancerGroups());
+
+      if (maybeOriginalService.isPresent()) {
+        loadBalancerGroupsToUpdate.addAll(maybeOriginalService.get().getLoadBalancerGroups());
+      }
+      for (String group : loadBalancerGroupsToUpdate) {
+        if (requestsByGroup.containsKey(group)) {
+            requestsByGroup.get(group).add(new BaragonRequestBatchItem(request.getLoadBalancerRequestId(), request.getAction(), InternalStatesMap.getRequestType(queuedRequestWithState.getCurrentState())));
+        } else {
+          requestsByGroup.put(group, Sets.newHashSet(new BaragonRequestBatchItem(request.getLoadBalancerRequestId(), request.getAction(), InternalStatesMap.getRequestType(queuedRequestWithState.getCurrentState()))));
+        }
+      }
+      results.put(queuedRequestWithState, InternalStatesMap.getWaitingState(queuedRequestWithState.getCurrentState()));
     }
 
-    final String requestId = request.getLoadBalancerRequestId();
-
-    for (final BaragonAgentMetadata agentMetadata : getAgents(loadBalancerGroupsToUpdate)) {
-      final String baseUrl = agentMetadata.getBaseAgentUri();
-
-      // wait until pending request has completed.
-      Optional<Long> maybePendingRequest = agentResponseDatastore.getPendingRequest(requestId, baseUrl);
-      if (maybePendingRequest.isPresent() && !((System.currentTimeMillis() - maybePendingRequest.get()) > baragonAgentRequestTimeout)) {
-        LOG.info(String.format("Request has been processing for %s ms", (System.currentTimeMillis() - maybePendingRequest.get())));
-        continue;
+    for (Map.Entry<String, Set<BaragonRequestBatchItem>> entry : requestsByGroup.entrySet()) {
+      for (final BaragonAgentMetadata agentMetadata : loadBalancerDatastore.getAgentMetadata(entry.getKey())) {
+        final String baseUrl = agentMetadata.getBaseAgentUri();
+        if (agentMetadata.isBatchEnabled()) {
+          sendBatchRequest(baseUrl, entry.getValue());
+        } else {
+          for (BaragonRequestBatchItem batchItem : entry.getValue()) {
+            sendIndividualRequest(baseUrl, batchItem.getRequestId(), batchItem.getRequestType());
+          }
+        }
       }
+    }
 
-      final Optional<AgentResponseId> maybeLastResponseId = agentResponseDatastore.getLastAgentResponseId(requestId, requestType, baseUrl);
+    return results;
+  }
 
-      // don't retry request if we've hit the max attempts, or the request was successful
-      if (maybeLastResponseId.isPresent() && (maybeLastResponseId.get().getAttempt() > baragonAgentMaxAttempts || maybeLastResponseId.get().isSuccess())) {
-        continue;
+  private void sendBatchRequest(final String baseUrl, final Set<BaragonRequestBatchItem> batch) {
+    Set<BaragonRequestBatchItem> doNotSend = Sets.newHashSet();
+    for (BaragonRequestBatchItem item : batch) {
+      if (!shouldSendRequest(baseUrl, item.getRequestId(), item.getRequestType())) {
+        doNotSend.add(item);
+      } else {
+        agentResponseDatastore.setPendingRequestStatus(item.getRequestId(), baseUrl, true);
       }
+    }
+    batch.removeAll(doNotSend);
 
-      agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, true);
+    final String url = String.format(baragonAgentBatchRequestUriFormat, baseUrl);
 
-      final String url = String.format(baragonAgentRequestUriFormat, baseUrl, requestId);
-
-      try {
-        buildAgentRequest(url, requestType).execute(new AsyncCompletionHandler<Void>() {
-          @Override
-          public Void onCompleted(Response response) throws Exception {
-            LOG.info(String.format("Got HTTP %d from %s for %s", response.getStatusCode(), baseUrl, requestId));
-            final Optional<String> content = Strings.isNullOrEmpty(response.getResponseBody()) ? Optional.<String>absent() : Optional.of(response.getResponseBody());
-            agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.of(response.getStatusCode()), content, Optional.<String>absent());
-            agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
+    try {
+      buildAgentBatchRequest(url, batch).execute(new AsyncCompletionHandler<Void>() {
+        @Override
+        public Void onCompleted(Response response) throws Exception {
+          LOG.info("Got HTTP {} from {} for batch request {}", response.getStatusCode(), baseUrl, batch);
+          Set<String> handledRequestIds = Sets.newHashSet();
+          if (response.getStatusCode() >= 300) {
+            LOG.error("Received invalid response from agent (status: {}, response: {})", response.getStatusCode(), response.getResponseBody());
+            for (BaragonRequestBatchItem item : batch) {
+              if (!handledRequestIds.contains(item.getRequestId())) {
+                agentResponseDatastore.addAgentResponse(item.getRequestId(), item.getRequestType(), baseUrl, url, Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(String.format("Caught exception processing agent response %s", response)));
+                agentResponseDatastore.setPendingRequestStatus(item.getRequestId(), baseUrl, false);
+              }
+            }
             return null;
           }
-
-          @Override
-          public void onThrowable(Throwable t) {
-            LOG.info(String.format("Got exception %s when hitting %s for %s", t, baseUrl, requestId));
-            agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.<Integer>absent(), Optional.<String>absent(), Optional.of(t.getMessage()));
-            agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
+          Set<AgentBatchResponseItem> responses = objectMapper.readValue(response.getResponseBody(), new TypeReference<Set<AgentBatchResponseItem>>(){});
+          for (AgentBatchResponseItem agentResponse : responses) {
+            agentResponseDatastore.addAgentResponse(agentResponse.getRequestId(), agentResponse.getRequestType(), baseUrl, url, Optional.of(agentResponse.getStatusCode()), agentResponse.getMessage(), Optional.<String>absent());
+            agentResponseDatastore.setPendingRequestStatus(agentResponse.getRequestId(), baseUrl, false);
+            handledRequestIds.add(agentResponse.getRequestId());
           }
-        });
-      } catch (Exception e) {
-        LOG.info(String.format("Got exception %s when hitting %s for %s", e, baseUrl, requestId));
-        agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.<Integer>absent(), Optional.<String>absent(), Optional.of(e.getMessage()));
-        agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
+          for (BaragonRequestBatchItem item : batch) {
+            if (!handledRequestIds.contains(item.getRequestId())) {
+              agentResponseDatastore.addAgentResponse(item.getRequestId(), item.getRequestType(), baseUrl, url, Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(String.format("No response in batch for request %s", item.getRequestId())));
+              agentResponseDatastore.setPendingRequestStatus(item.getRequestId(), baseUrl, false);
+            }
+          }
+          return null;
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+          LOG.info("Got exception {} when hitting {} with batch request {}", t, baseUrl, batch);
+          for (BaragonRequestBatchItem item : batch) {
+            agentResponseDatastore.addAgentResponse(item.getRequestId(), item.getRequestType(), baseUrl, url, Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(t.getMessage()));
+            agentResponseDatastore.setPendingRequestStatus(item.getRequestId(), baseUrl, false);
+          }
+        }
+      });
+    } catch (Exception e) {
+      LOG.info("Got exception {} when hitting {} with batch reqeust {}", e, baseUrl, batch);
+      for (BaragonRequestBatchItem item : batch) {
+        agentResponseDatastore.addAgentResponse(item.getRequestId(), item.getRequestType(), baseUrl, url, Optional.<Integer> absent(), Optional.<String> absent(), Optional.of(e.getMessage()));
+        agentResponseDatastore.setPendingRequestStatus(item.getRequestId(), baseUrl, false);
       }
+    }
+
+  }
+
+  private boolean shouldSendRequest(String baseUrl, String requestId, AgentRequestType requestType) {
+    Optional<Long> maybePendingRequest = agentResponseDatastore.getPendingRequest(requestId, baseUrl);
+    if (maybePendingRequest.isPresent() && !((System.currentTimeMillis() - maybePendingRequest.get()) > baragonAgentRequestTimeout)) {
+      LOG.info(String.format("Request has been processing for %s ms", (System.currentTimeMillis() - maybePendingRequest.get())));
+      return false;
+    }
+
+    final Optional<AgentResponseId> maybeLastResponseId = agentResponseDatastore.getLastAgentResponseId(requestId, requestType, baseUrl);
+
+    // don't retry request if we've hit the max attempts, or the request was successful
+    if (maybeLastResponseId.isPresent() && (maybeLastResponseId.get().getAttempt() > baragonAgentMaxAttempts || maybeLastResponseId.get().isSuccess())) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private void sendIndividualRequest(final String baseUrl, final String requestId, final AgentRequestType requestType) {
+    if (!shouldSendRequest(baseUrl, requestId, requestType)) {
+      return;
+    }
+
+    agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, true);
+
+    final String url = String.format(baragonAgentRequestUriFormat, baseUrl, requestId);
+
+    try {
+      buildAgentRequest(url, requestType).execute(new AsyncCompletionHandler<Void>() {
+        @Override
+        public Void onCompleted(Response response) throws Exception {
+          LOG.info(String.format("Got HTTP %d from %s for %s", response.getStatusCode(), baseUrl, requestId));
+          final Optional<String> content = Strings.isNullOrEmpty(response.getResponseBody()) ? Optional.<String>absent() : Optional.of(response.getResponseBody());
+          agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.of(response.getStatusCode()), content, Optional.<String>absent());
+          agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
+          return null;
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+          LOG.info(String.format("Got exception %s when hitting %s for %s", t, baseUrl, requestId));
+          agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.<Integer>absent(), Optional.<String>absent(), Optional.of(t.getMessage()));
+          agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
+        }
+      });
+    } catch (Exception e) {
+      LOG.info(String.format("Got exception %s when hitting %s for %s", e, baseUrl, requestId));
+      agentResponseDatastore.addAgentResponse(requestId, requestType, baseUrl, url, Optional.<Integer>absent(), Optional.<String>absent(), Optional.of(e.getMessage()));
+      agentResponseDatastore.setPendingRequestStatus(requestId, baseUrl, false);
     }
   }
 
@@ -160,7 +283,7 @@ public class AgentManager {
       Optional<Long> maybePendingRequestTime = agentResponseDatastore.getPendingRequest(request.getLoadBalancerRequestId(), baseUrl);
       if (maybePendingRequestTime.isPresent()) {
         if ((System.currentTimeMillis() - maybePendingRequestTime.get()) > baragonAgentRequestTimeout) {
-          LOG.info(String.format("Request %s reached maximum pending request time", request.getLoadBalancerRequestId()));
+          LOG.info("Request {} reached maximum pending request time", request.getLoadBalancerRequestId());
           agentResponseDatastore.setPendingRequestStatus(request.getLoadBalancerRequestId(), baseUrl, false);
           return AgentRequestsStatus.FAILURE;
         } else {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -3,6 +3,8 @@ package com.hubspot.baragon.service.worker;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,6 +24,7 @@ import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.InternalRequestStates;
 import com.hubspot.baragon.models.InternalStatesMap;
 import com.hubspot.baragon.models.QueuedRequestId;
+import com.hubspot.baragon.models.QueuedRequestWithState;
 import com.hubspot.baragon.models.RequestAction;
 import com.hubspot.baragon.service.exceptions.BaragonExceptionNotifier;
 import com.hubspot.baragon.service.managers.AgentManager;
@@ -151,8 +154,7 @@ public class BaragonRequestWorker implements Runnable {
       case SEND_APPLY_REQUESTS:
       case FAILED_SEND_REVERT_REQUESTS:
       case CANCELLED_SEND_REVERT_REQUESTS:
-        agentManager.sendRequests(request, InternalStatesMap.getRequestType(currentState));
-        return InternalStatesMap.getWaitingState(currentState);
+        throw new RuntimeException(String.format("Requests in state %s must be handled by batch request sender", currentState));
 
       case FAILED_CHECK_REVERT_RESPONSES:
       case CANCELLED_CHECK_REVERT_RESPONSES:
@@ -182,37 +184,22 @@ public class BaragonRequestWorker implements Runnable {
     return message.substring(0, message.length() -1) + " ]";
   }
 
-  public void handleQueuedRequest(QueuedRequestId queuedRequestId) {
-    final String requestId = queuedRequestId.getRequestId();
-
-    final Optional<InternalRequestStates> maybeState = requestManager.getRequestState(requestId);
-
-    if (!maybeState.isPresent()) {
-      LOG.warn(String.format("%s does not have a request status!", requestId));
-      return;
+  public Map<QueuedRequestWithState, InternalRequestStates> handleQueuedRequests(Set<QueuedRequestWithState> queuedRequestsWithState) {
+    Map<QueuedRequestWithState, InternalRequestStates> results = new HashMap<>();
+    Set<QueuedRequestWithState> toApply = Sets.newHashSet();
+    for (QueuedRequestWithState queuedRequestWithState : queuedRequestsWithState) {
+      if (!queuedRequestWithState.getCurrentState().isRequireAgentRequest()) {
+        try {
+          results.put(queuedRequestWithState, handleState(queuedRequestWithState.getCurrentState(), queuedRequestWithState.getRequest()));
+        } catch (Exception e) {
+          LOG.error("Error processing request {}", queuedRequestWithState.getRequest().getLoadBalancerRequestId(), e);
+        }
+      } else {
+        toApply.add(queuedRequestWithState);
+      }
     }
-
-    final InternalRequestStates currentState = maybeState.get();
-
-    final Optional<BaragonRequest> maybeRequest = requestManager.getRequest(requestId);
-
-    if (!maybeRequest.isPresent()) {
-      LOG.warn(String.format("%s does not have a request object!", requestId));
-      return;
-    }
-
-    final InternalRequestStates newState = handleState(currentState, maybeRequest.get());
-
-    if (newState != currentState) {
-      LOG.info(String.format("%s: %s --> %s", requestId, currentState, newState));
-      requestManager.setRequestState(requestId, newState);
-    }
-
-    if (InternalStatesMap.isRemovable(newState)) {
-      requestManager.removeQueuedRequest(queuedRequestId);
-      requestManager.saveResponseToHistory(maybeRequest.get(), newState);
-      requestManager.deleteRequest(requestId);
-    }
+    results.putAll(agentManager.sendRequests(toApply));
+    return results;
   }
 
   @Override
@@ -223,14 +210,40 @@ public class BaragonRequestWorker implements Runnable {
       final List<QueuedRequestId> queuedRequestIds = requestManager.getQueuedRequestIds();
 
       if (!queuedRequestIds.isEmpty()) {
-        final Set<String> handledServices = Sets.newHashSet();  // only handle one request per service at a time
-
+        final Set<String> handledServices = Sets.newHashSet();
+        final Set<QueuedRequestWithState> queuedRequestsWithState = Sets.newHashSet();
         for (QueuedRequestId queuedRequestId : queuedRequestIds) {
-          if (!handledServices.contains(queuedRequestId.getServiceId())) {
-            synchronized (BaragonRequestWorker.class) {
-              handleQueuedRequest(queuedRequestId);
-            }
-            handledServices.add(queuedRequestId.getServiceId());
+          final String requestId = queuedRequestId.getRequestId();
+          final Optional<InternalRequestStates> maybeState = requestManager.getRequestState(requestId);
+
+          if (!maybeState.isPresent()) {
+            LOG.warn(String.format("%s does not have a request status!", requestId));
+            continue;
+          }
+
+          final Optional<BaragonRequest> maybeRequest = requestManager.getRequest(requestId);
+
+          if (!maybeRequest.isPresent()) {
+            LOG.warn(String.format("%s does not have a request object!", requestId));
+            continue;
+          }
+
+          queuedRequestsWithState.add(new QueuedRequestWithState(queuedRequestId, maybeRequest.get(), maybeState.get()));
+          handledServices.add(queuedRequestId.getServiceId());
+        }
+
+        Map<QueuedRequestWithState, InternalRequestStates> results = handleQueuedRequests(queuedRequestsWithState);
+
+        for (Map.Entry<QueuedRequestWithState, InternalRequestStates> result : results.entrySet()) {
+          if (result.getValue() != result.getKey().getCurrentState()) {
+            LOG.info(String.format("%s: %s --> %s", result.getKey().getQueuedRequestId().getRequestId(), result.getKey().getCurrentState(), result.getValue()));
+            requestManager.setRequestState(result.getKey().getQueuedRequestId().getRequestId(), result.getValue());
+          }
+
+          if (InternalStatesMap.isRemovable(result.getValue())) {
+            requestManager.removeQueuedRequest(result.getKey().getQueuedRequestId());
+            requestManager.saveResponseToHistory(result.getKey().getRequest(), result.getValue());
+            requestManager.deleteRequest(result.getKey().getQueuedRequestId().getRequestId());
           }
         }
       }

--- a/BaragonService/src/test/java/com/hubspot/baragon/BaragonServiceTestModule.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/BaragonServiceTestModule.java
@@ -2,6 +2,10 @@ package com.hubspot.baragon;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.inject.AbstractModule;
@@ -19,12 +23,17 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
+import org.slf4j.LoggerFactory;
 
 public class BaragonServiceTestModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(TestingServer.class).in(Scopes.SINGLETON);
     bind(BaragonLoadBalancerDatastore.class).to(BaragonLoadBalancerTestDatastore.class).in(Scopes.SINGLETON);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    rootLogger.setLevel(Level.ERROR);
   }
 
   @Singleton
@@ -61,9 +70,7 @@ public class BaragonServiceTestModule extends AbstractModule {
   @Provides
   public ObjectMapper provideObjectMapper() {
     final ObjectMapper objectMapper = new ObjectMapper();
-
     objectMapper.registerModule(new GuavaModule());
-
     return objectMapper;
   }
 }

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/BaragonLoadBalancerTestDatastore.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/BaragonLoadBalancerTestDatastore.java
@@ -46,4 +46,13 @@ public class BaragonLoadBalancerTestDatastore extends BaragonLoadBalancerDatasto
       return super.getAgentMetadata(clusterNames);
     }
   }
+
+  @Override
+  public Collection<BaragonAgentMetadata> getAgentMetadata(String clusterName) {
+    if (loadBalancerAgentsOverride.isPresent()) {
+      return loadBalancerAgentsOverride.get();
+    } else {
+      return super.getAgentMetadata(clusterName);
+    }
+  }
 }

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(JukitoRunner.class)
-public class KnownAgentTests {
+public class KnownAgentTest {
   public static final String CLUSTER_NAME = "test-cluster";
   public static final String AGENT_ID = "123.123.123.123:8080";
   public static final String BASE_URI = "http://123.123.123.123:8080/baragon-agent/v2";
@@ -33,7 +33,7 @@ public class KnownAgentTests {
 
   @Test
   public void testKnownAgentBaragonMetadata(BaragonKnownAgentsDatastore datastore) {
-    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), System.currentTimeMillis());
+    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), true, System.currentTimeMillis());
     datastore.addKnownAgent(CLUSTER_NAME, metadata);
 
     assertEquals(Collections.singletonList(metadata), datastore.getKnownAgentsMetadata(CLUSTER_NAME));
@@ -41,7 +41,7 @@ public class KnownAgentTests {
 
   @Test
   public void testKnownAgentString() {
-    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap()), BaragonAgentMetadata.fromString(BASE_URI));
+    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
   }
 
   @Test( expected = InvalidAgentMetadataStringException.class )

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
@@ -89,7 +89,7 @@ public class RequestTest {
     final String requestId = "test-126";
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(FAKE_LB_GROUP);
-    final BaragonService service = new BaragonService("testservice", Collections.<String>emptyList(), "/test", lbGroup, Collections.<String, Object>emptyMap());
+    final BaragonService service = new BaragonService("testservice1", Collections.<String>emptyList(), "/test", lbGroup, Collections.<String, Object>emptyMap());
 
     final UpstreamInfo upstream = new UpstreamInfo("testhost:8080", Optional.of(requestId), Optional.<String>absent());
 
@@ -116,7 +116,7 @@ public class RequestTest {
     final String requestId = "test-127";
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(FAKE_LB_GROUP);
-    final BaragonService service = new BaragonService("testservice", Collections.<String>emptyList(), "/test", lbGroup, Collections.<String, Object>emptyMap());
+    final BaragonService service = new BaragonService("testservice2", Collections.<String>emptyList(), "/test", lbGroup, Collections.<String, Object>emptyMap());
 
     final UpstreamInfo upstream = new UpstreamInfo("testhost:8080", Optional.of(requestId), Optional.<String>absent());
 
@@ -134,7 +134,7 @@ public class RequestTest {
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(REAL_LB_GROUP);
 
-    final BaragonService service = new BaragonService("testservice", Collections.<String>emptyList(), "/foo", lbGroup, Collections.<String, Object>emptyMap());
+    final BaragonService service = new BaragonService("testservice3", Collections.<String>emptyList(), "/foo", lbGroup, Collections.<String, Object>emptyMap());
 
     final UpstreamInfo upstream = new UpstreamInfo("testhost:8080", Optional.of(requestId), Optional.<String>absent());
 
@@ -163,7 +163,7 @@ public class RequestTest {
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(REAL_LB_GROUP);
 
-    final BaragonService service = new BaragonService("testservice", Collections.<String>emptyList(), "/foo", Collections.singletonList("/some-other-path"), lbGroup, Collections.<String, Object>emptyMap(), Optional.<String>absent(), Collections.<String>emptySet());
+    final BaragonService service = new BaragonService("testservice4", Collections.<String>emptyList(), "/foo", Collections.singletonList("/some-other-path"), lbGroup, Collections.<String, Object>emptyMap(), Optional.<String>absent(), Collections.<String>emptySet());
 
     final UpstreamInfo upstream = new UpstreamInfo("testhost:8080", Optional.of(requestId), Optional.<String>absent());
 

--- a/BaragonServiceIntegrationTests/pom.xml
+++ b/BaragonServiceIntegrationTests/pom.xml
@@ -60,9 +60,8 @@
     </dependency>
 
     <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <scope>test</scope>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
     </dependency>
 
   </dependencies>

--- a/BaragonServiceIntegrationTests/src/test/java/com/hubspot/baragon/BaragonServiceTestIT.java
+++ b/BaragonServiceIntegrationTests/src/test/java/com/hubspot/baragon/BaragonServiceTestIT.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
-
 public class BaragonServiceTestIT {
   
   public static final String LOAD_BALANCER_GROUP = "docker-baragon";
@@ -97,7 +96,6 @@ public class BaragonServiceTestIT {
       
       state = baragonServiceClient.getRequest(requestId).get().getLoadBalancerState(); 
     }
-    LOG.info("");
     BaragonResponse resp = baragonServiceClient.getRequest(requestId).get();
     if (!resp.getLoadBalancerState().equals(targetState)) {
       throw new Exception("Request " + requestId + " stuck while waiting to reach " + targetState + ": \n" +

--- a/BaragonServiceIntegrationTests/src/test/java/com/hubspot/baragon/DockerTestModule.java
+++ b/BaragonServiceIntegrationTests/src/test/java/com/hubspot/baragon/DockerTestModule.java
@@ -4,6 +4,12 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
@@ -34,5 +40,8 @@ public class DockerTestModule extends AbstractModule {
     final int baragonPort = Integer.parseInt(System.getProperty("baragon.service.port"));
     install(new BaragonClientModule(Arrays.asList(String.format("%s:%d", getDockerAddress().or("localhost"), baragonPort))));
     BaragonClientModule.bindAuthkey(binder()).toInstance(Optional.fromNullable(Strings.emptyToNull(System.getProperty("baragon.service.auth.key"))));
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    rootLogger.setLevel(Level.INFO);
   }
 }

--- a/BaragonUI/app/templates/status.hbs
+++ b/BaragonUI/app/templates/status.hbs
@@ -5,7 +5,6 @@
                 <li class="list-group-item"><h4>Request Worker Lag <span class="pull-right">{{workerLagHumanize status.workerLagMs }}</span></h4></li>
                 <li class="list-group-item"><h4>Elb Worker Lag <span class="pull-right">{{workerLagHumanize status.elbWorkerLagMs }}</span></h4></li>
                 <li class="list-group-item"><h4>ZK Connection State <span class="pull-right">{{ status.zookeeperState }}</span></h4></li>
-                <li class="list-group-item"><h4>ZK State Node Size <span class="pull-right">{{humanizeFileSize status.globalStateNodeSize}}</span></h4></li>
                 <li class="list-group-item">
                     <h4>BaragonService Workers</h4>
                     <ul class="list-group">


### PR DESCRIPTION
In some situations Baragon is not fast enough due to requiring too many load balancer config reloads to make all of its updates. This will batch requests together so that if there are multiple requests for the same agent, they will be executed at once, requiring multiple config checks, but only a single reload. This is meant to be done completely behind the scenes and be backwards compatible:

- Each agent has a `batchEnabled` property which it will set to true. But the value will default to false if not present (i.e. BaragonService reading data for an older agent version)
- BaragonService has the logic to apply in batch or individual request mode, it will use batch whenever possible
- Agents will have both a batch and regular apply endpoint

@tpetr 