### PR TITLE
fix docker compose yaml to get hostname properly

### DIFF
--- a/BaragonService/src/main/docker/start.sh
+++ b/BaragonService/src/main/docker/start.sh
@@ -2,16 +2,17 @@
 
 if [ ${DOCKER_HOST} ]; then
 	HOST_AND_PORT=`echo $DOCKER_HOST | awk -F/ '{print $3}'`
-	HOST_IP="${HOST_AND_PORT%:*}"
+	BARAGON_HOSTNAME="${BARAGON_HOSTNAME:=HOST_AND_PORT%:*}"
 fi
 
-DEFAULT_URI_BASE="http://${HOST_IP:=localhost}:${BARAGON_PORT:=8080}${BARAGON_UI_BASE:=/baragon/v2}"
+DEFAULT_URI_BASE="http://${BARAGON_HOSTNAME:=localhost}:${BARAGON_PORT:=8080}${BARAGON_UI_BASE:=/baragon/v2}"
 
 [[ ! ${BARAGON_ZK_NAMESPACE:-} ]] || args+=( -Ddw.zookeeper.zkNamespace="$BARAGON_ZK_NAMESPACE" )
 [[ ! ${BARAGON_ZK_QUORUM:-} ]] || args+=( -Ddw.zookeeper.quorum="$BARAGON_ZK_QUORUM" )
 [[ ! ${BARAGON_PORT:-} ]] || args+=( -Ddw.server.connector.port="$BARAGON_PORT" )
 [[ ! ${BARAGON_AUTH_ENABLED:-} ]] || args+=( -Ddw.auth.enabled="$BARAGON_AUTH_ENABLED" )
 [[ ! ${BARAGON_AUTH_KEY:-} ]] || args+=( -Ddw.auth.key="$BARAGON_AUTH_KEY" )
+[[ ! ${BARAGON_HOSTNAME:-} ]] || args+=( -Ddw.hostname="$BARAGON_HOSTNAME" )
 
 args+=( -Ddw.ui.baseUrl="${BARAGON_UI_BASE_URL:=$DEFAULT_URI_BASE}" )
 


### PR DESCRIPTION
As mentioned in https://github.com/HubSpot/Singularity/issues/1107 , for newer docker versions grabbing the hostname via `InetAddress` does not work when running the container in host mode. This adds a way to set the hostname via an environment variable, and will automatically find it for you when using docker-compose (i.e. DOCKER_HOST var is passed in)