### PR TITLE
add noServiceUpdate field, for not updating the service when applying a request

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -45,6 +45,9 @@ public class BaragonRequest {
   @NotNull
   private final boolean noReload;
 
+  @NotNull
+  private final boolean noServiceUpdate;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
@@ -54,7 +57,8 @@ public class BaragonRequest {
                         @JsonProperty("replaceServiceId") Optional<String> replaceServiceId,
                         @JsonProperty("action") Optional<RequestAction> action,
                         @JsonProperty("noValidate") boolean noValidate,
-                        @JsonProperty("noReload") boolean noReload) {
+                        @JsonProperty("noReload") boolean noReload,
+                        @JsonProperty("noServiceUpdate") boolean noServiceUpdate) {
     this.loadBalancerRequestId = loadBalancerRequestId;
     this.loadBalancerService = loadBalancerService;
     this.addUpstreams = addRequestId(addUpstreams, loadBalancerRequestId);
@@ -64,19 +68,20 @@ public class BaragonRequest {
     this.replaceUpstreams = Objects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
     this.noValidate = Objects.firstNonNull(noValidate, false);
     this.noReload = noReload;
+    this.noServiceUpdate = noServiceUpdate;
 
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false, false);
   }
 
   public String getLoadBalancerRequestId() {
@@ -136,6 +141,10 @@ public class BaragonRequest {
     return noReload;
   }
 
+  public boolean isNoServiceUpdate() {
+    return noServiceUpdate;
+  }
+
   @Override
   public String toString() {
     return "BaragonRequest [" +
@@ -147,6 +156,7 @@ public class BaragonRequest {
         ", action=" + action +
         ", noValidate=" + noValidate +
         ", noReload=" + noReload +
+        ", noServiceUpdate=" + noServiceUpdate +
         ']';
   }
 
@@ -185,6 +195,9 @@ public class BaragonRequest {
     if (!noReload == request.noReload) {
       return false;
     }
+    if (!noServiceUpdate == request.noServiceUpdate) {
+      return false;
+    }
 
     return true;
   }
@@ -199,6 +212,7 @@ public class BaragonRequest {
     result = 31 * result + action.hashCode();
     result = 31 * result + (noValidate ? 1 : 0);
     result = 31 * result + (noReload ? 1 : 0);
+    result = 31 * result + (noServiceUpdate ? 1 : 0);
     return result;
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -107,12 +107,17 @@ public class BaragonStateDatastore extends AbstractDataStore {
     }
 
     CuratorTransaction transaction = curatorFramework.inTransaction();
-    if (!request.isNoServiceUpdate()) {
-      if (nodeExists(servicePath)) {
+
+    if (nodeExists(servicePath)) {
+      if (!request.isNoServiceUpdate()) {
         transaction = transaction.setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
+        LOG.info("Updating service '{}'", request.getLoadBalancerService().getServiceId());
       } else {
-        transaction = transaction.create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
+        LOG.info("Not updating service '{}' because noServiceUpdate=true", request.getLoadBalancerService().getServiceId());
       }
+    } else {
+      LOG.info("Creating ZK node for service '{}'", request.getLoadBalancerService().getServiceId());
+      transaction = transaction.create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     }
 
     List<String> pathsToDelete = new ArrayList<>();

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -1,5 +1,22 @@
 package com.hubspot.baragon.data;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.transaction.CuratorTransaction;
+import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
@@ -15,21 +32,6 @@ import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.baragon.utils.ZkParallelFetcher;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
-import org.apache.curator.utils.ZKPaths;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 @Singleton
 public class BaragonStateDatastore extends AbstractDataStore {
@@ -99,11 +101,18 @@ public class BaragonStateDatastore extends AbstractDataStore {
     String serviceId = request.getLoadBalancerService().getServiceId();
     Collection<UpstreamInfo> currentUpstreams = getUpstreams(serviceId);
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
-    CuratorTransactionFinal transaction;
-    if (nodeExists(servicePath)) {
-      transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
-    } else {
-      transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
+
+    if (!request.isNoServiceUpdate() && !nodeExists(servicePath)) {
+      throw new RuntimeException("BaragonRequest " + request.getLoadBalancerRequestId() + " has noServiceUpdate=true, but no BaragonService exists!");  // TODO: better exception?
+    }
+
+    CuratorTransaction transaction = curatorFramework.inTransaction();
+    if (!request.isNoServiceUpdate()) {
+      if (nodeExists(servicePath)) {
+        transaction = transaction.setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
+      } else {
+        transaction = transaction.create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
+      }
     }
 
     List<String> pathsToDelete = new ArrayList<>();
@@ -161,7 +170,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
         }
       }
     }
-    transaction.commit();
+    ((CuratorTransactionFinal)transaction).commit();
   }
 
   private List<String> matchingUpstreamPaths(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toAdd) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ServiceManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ServiceManager.java
@@ -58,7 +58,7 @@ public class ServiceManager {
     Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
     if (maybeService.isPresent()) {
       try {
-        return requestManager.enqueueRequest(buildRemoveRequest(maybeService.get(), requestId, noValidate, noReload));
+        return requestManager.enqueueRequest(buildRemoveRequest(maybeService.get(), requestId, noValidate, noReload, false));
       } catch (Exception e) {
         return BaragonResponse.failure(requestId, e.getMessage());
       }
@@ -67,15 +67,15 @@ public class ServiceManager {
     }
   }
 
-  private BaragonRequest buildRemoveRequest(BaragonService service, String requestId, boolean noValidate, boolean noReload) throws Exception {
+  private BaragonRequest buildRemoveRequest(BaragonService service, String requestId, boolean noValidate, boolean noReload, boolean noServiceUpdate) throws Exception {
     List<UpstreamInfo> empty = Collections.emptyList();
     List<UpstreamInfo> remove;
     remove =  new ArrayList<>(stateDatastore.getUpstreams(service.getServiceId()));
-    return new BaragonRequest(requestId, service, empty, remove, empty, Optional.<String>absent(), Optional.of(RequestAction.DELETE), noValidate, noReload);
+    return new BaragonRequest(requestId, service, empty, remove, empty, Optional.<String>absent(), Optional.of(RequestAction.DELETE), noValidate, noReload, noServiceUpdate);
   }
 
   private BaragonRequest buildReloadRequest(BaragonService service, String requestId, boolean noValidate) {
     List<UpstreamInfo> empty = Collections.emptyList();
-    return new BaragonRequest(requestId, service, empty, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD), noValidate, false);
+    return new BaragonRequest(requestId, service, empty, empty, empty, Optional.<String>absent(), Optional.of(RequestAction.RELOAD), noValidate, false, false);
   }
 }


### PR DESCRIPTION
Should be useful for traffic splitting scenarios in Singularity. If `noServiceUpdate` is set to `true` on a BaragonRequest, Baragon will use the `serviceId` but not actually overwrite the BaragonService object.

/cc @ssalinas 
