### PR TITLE
Be sure to reload at end of batch

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
@@ -28,12 +28,12 @@ public class RequestResource {
 
   @POST
   public Response apply(@PathParam("requestId") String requestId) throws InterruptedException {
-    return agentRequestManager.processRequest(requestId, Optional.<RequestAction>absent(), false);
+    return agentRequestManager.processRequest(requestId, Optional.<RequestAction>absent(), false, Optional.<Integer>absent());
   }
 
   @DELETE
   public Response revert(@PathParam("requestId") String requestId) throws InterruptedException {
-    return agentRequestManager.processRequest(requestId, Optional.of(RequestAction.REVERT), false);
+    return agentRequestManager.processRequest(requestId, Optional.of(RequestAction.REVERT), false, Optional.<Integer>absent());
   }
 
 }


### PR DESCRIPTION
Currently if the last item in a request batch is a no-op (configs are unchanged), BaragonAgent will not trigger a reload, meaning previous changes may not be correctly loaded. This updates the unchanged configs check to reload when applicable before returning.