### PR TITLE
create persistent sequential node with empty bytes

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/AbstractDataStore.java
@@ -185,7 +185,7 @@ public abstract class AbstractDataStore {
     final long start = System.currentTimeMillis();
 
     try {
-      final String result = curatorFramework.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath(path, new byte[] {});
+      final String result = curatorFramework.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath(path);
       log(OperationType.WRITE, Optional.<Integer>absent(), Optional.<Integer>absent(), start, path);
       return result;
     } catch (Exception e) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -231,7 +231,7 @@ public class BaragonServiceModule extends AbstractModule {
       .sessionTimeoutMs(config.getSessionTimeoutMillis())
       .connectionTimeoutMs(config.getConnectTimeoutMillis())
       .retryPolicy(new ExponentialBackoffRetry(config.getRetryBaseSleepTimeMilliseconds(), config.getRetryMaxTries()))
-      .defaultData(new byte[] {})
+      .defaultData(new byte[0])
       .build();
 
     client.getConnectionStateListenable().addListener(connectionStateListener);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -226,11 +226,13 @@ public class BaragonServiceModule extends AbstractModule {
   @Singleton
   @Provides
   public CuratorFramework provideCurator(ZooKeeperConfiguration config, BaragonConnectionStateListener connectionStateListener) {
-    CuratorFramework client = CuratorFrameworkFactory.newClient(
-      config.getQuorum(),
-      config.getSessionTimeoutMillis(),
-      config.getConnectTimeoutMillis(),
-      new ExponentialBackoffRetry(config.getRetryBaseSleepTimeMilliseconds(), config.getRetryMaxTries()));
+    CuratorFramework client = CuratorFrameworkFactory.builder()
+      .connectString(config.getQuorum())
+      .sessionTimeoutMs(config.getSessionTimeoutMillis())
+      .connectionTimeoutMs(config.getConnectTimeoutMillis())
+      .retryPolicy(new ExponentialBackoffRetry(config.getRetryBaseSleepTimeMilliseconds(), config.getRetryMaxTries()))
+      .defaultData(new byte[] {})
+      .build();
 
     client.getConnectionStateListenable().addListener(connectionStateListener);
 


### PR DESCRIPTION
@tpetr `ObjectMapper` will still throw an error if it's given empty bytes. So I modified the readFromZk method to check for data length as well as updating the persistent sequential to be created with empty bytes. If we get empty bytes we return an absent

Context for others:
- When curator creates a persistent sequential node with no argument for content/data, it defaults the data to the ip of the client creating it. It was possible that BaragonService would try to read this in between the creation of the node and setting the data in  the `addAgentResponse` method in the `BaragonAgentResponseDatastore`
