### PR TITLE
Fix for reverts in batch requests

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -85,17 +85,17 @@ public class AgentRequestManager {
   }
 
   private Optional<RequestAction> actionForBatchItem(BaragonRequestBatchItem item) {
-    if (item.getRequestAction().isPresent()) {
-      return item.getRequestAction();
-    } else {
-      switch (item.getRequestType()) {
-        case REVERT:
-        case CANCEL:
-          return Optional.of(RequestAction.REVERT);
-        case APPLY:
-        default:
+    switch (item.getRequestType()) {
+      case REVERT:
+      case CANCEL:
+        return Optional.of(RequestAction.REVERT);
+      case APPLY:
+      default:
+        if (item.getRequestAction().isPresent()) {
+          return item.getRequestAction();
+        } else {
           return Optional.of(RequestAction.UPDATE);
-      }
+        }
     }
   }
 


### PR DESCRIPTION
Found this the other day. A number of our reverts for requests in the middle of batches were not operating correctly (were attempting to apply instead of revert). It never presented itself since the agents automatically revert to backup files when things fail anyways, but this will make it much cleaner.