### PR TITLE
Correctly grab group/rack attributes from model

### DIFF
--- a/BaragonUI/app/models/Service.coffee
+++ b/BaragonUI/app/models/Service.coffee
@@ -89,7 +89,7 @@ class Service extends Model
                         loadBalancerGroups: @attributes.service.loadBalancerGroups
                         options: @attributes.options
                     addUpstreams: []
-                    removeUpstreams: [getByUpsteamName(upstream, requestId)]
+                    removeUpstreams: [@getByUpsteamName(upstream, requestId)]
                     noValidate: noValidate,
                     noReload: noReload
                 }

--- a/BaragonUI/app/models/Service.coffee
+++ b/BaragonUI/app/models/Service.coffee
@@ -89,7 +89,7 @@ class Service extends Model
                         loadBalancerGroups: @attributes.service.loadBalancerGroups
                         options: @attributes.options
                     addUpstreams: []
-                    removeUpstreams: [{upstream: upstream, request: requestId}]
+                    removeUpstreams: [getByUpsteamName(upstream, requestId)]
                     noValidate: noValidate,
                     noReload: noReload
                 }
@@ -101,6 +101,12 @@ class Service extends Model
         })
 
     requestId: -> "#{@serviceId}-#{Date.now()}"
+
+    getByUpsteamName: (upstream, requestId) =>
+        for key in @attributes.upstreams
+            if (key.upstream == upstream)
+              return $.extend({}, key, {requestId: requestId})
+        return {upstream: upstream, requestId: requestId}
 
 
     promptDelete: (callback) =>


### PR DESCRIPTION
The way that it was working was that only the name of the upstream being
grabbed; it was not looking up the group/rack attributes in the model at
all when you attempted to remove a single upstream.  This change uses
the name of the upstream to lookup the actual upstream object in the
model, then posts that request to the server.

The values that weren't `upstream` and `requestId` were the defaults;
they weren't really coming from anywhere, they were just being filled
in.