### PR TITLE
Upgrade docker-compose file version

### DIFF
--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -1,40 +1,39 @@
-zk:
-  image: bobrik/zookeeper
-  net: host
-  environment:
-    ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
-    ZK_ID: 1
-  expose:
-    - "2181"
-
-service:
-  image: hubspot/baragonservice:0.5.0-SNAPSHOT
-  net: host
-  environment:
-    - DOCKER_HOST
-    - BARAGON_PORT=8080
-    - BARAGON_UI_BASE=/baragon/v2
-
-agent1:
-  image: hubspot/baragonagent:0.5.0-SNAPSHOT
-  net: host
-  environment:
-    NGINX_PORT: 80
-    BARAGON_PORT: 8882
-    BARAGON_AGENT_GROUP: test
-  volumes:
-    - ./docker/configs/1/custom:/etc/nginx/conf.d/custom
-    - ./docker/configs/1/proxy:/etc/nginx/conf.d/proxy
-    - ./docker/configs/1/upstreams:/etc/nginx/conf.d/upstreams
-
-agent2:
-  image: hubspot/baragonagent:0.5.0-SNAPSHOT
-  net: host
-  environment:
-    NGINX_PORT: 81
-    BARAGON_PORT: 8883
-    BARAGON_AGENT_GROUP: test
-  volumes:
-    - ./docker/configs/2/custom:/etc/nginx/conf.d/custom
-    - ./docker/configs/2/proxy:/etc/nginx/conf.d/proxy
-    - ./docker/configs/2/upstreams:/etc/nginx/conf.d/upstreams
+version: '2.1'
+services:
+  zk:
+    image: bobrik/zookeeper
+    network_mode: host
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+    expose:
+      - 2181
+  service:
+    image: hubspot/baragonservice:0.5.0-SNAPSHOT
+    network_mode: host
+    environment:
+      DOCKER_HOST:
+      BARAGON_PORT: 8080
+      BARAGON_UI_BASE: /baragon/v2
+  agent1:
+    image: hubspot/baragonagent:0.5.0-SNAPSHOT
+    network_mode: host
+    environment:
+      NGINX_PORT: 80
+      BARAGON_PORT: 8882
+      BARAGON_AGENT_GROUP: test
+    volumes:
+      - ./docker/configs/1/custom:/etc/nginx/conf.d/custom
+      - ./docker/configs/1/proxy:/etc/nginx/conf.d/proxy
+      - ./docker/configs/1/upstreams:/etc/nginx/conf.d/upstreams
+  agent2:
+    image: hubspot/baragonagent:0.5.0-SNAPSHOT
+    network_mode: host
+    environment:
+      NGINX_PORT: 81
+      BARAGON_PORT: 8883
+      BARAGON_AGENT_GROUP: test
+    volumes:
+      - ./docker/configs/2/custom:/etc/nginx/conf.d/custom
+      - ./docker/configs/2/proxy:/etc/nginx/conf.d/proxy
+      - ./docker/configs/2/upstreams:/etc/nginx/conf.d/upstreams

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,39 @@
-zk:
-  image: bobrik/zookeeper
-  net: host
-  environment:
-    ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
-    ZK_ID: 1
-  expose:
-    - "2181"
-
-service:
-  image: hubspot/baragonservice:0.4.0
-  net: host
-  environment:
-    - DOCKER_HOST
-    - BARAGON_PORT=8080
-    - BARAGON_UI_BASE=/baragon/v2
-
-agent1:
-  image: hubspot/baragonagent:0.4.0
-  net: host
-  environment:
-    NGINX_PORT: 80
-    BARAGON_PORT: 8882
-    BARAGON_AGENT_GROUP: test
-  volumes:
-    - ./docker/configs/1/custom:/etc/nginx/conf.d/custom
-    - ./docker/configs/1/proxy:/etc/nginx/conf.d/proxy
-    - ./docker/configs/1/upstreams:/etc/nginx/conf.d/upstreams
-
-agent2:
-  image: hubspot/baragonagent:0.4.0
-  net: host
-  environment:
-    NGINX_PORT: 81
-    BARAGON_PORT: 8883
-    BARAGON_AGENT_GROUP: test
-  volumes:
-    - ./docker/configs/2/custom:/etc/nginx/conf.d/custom
-    - ./docker/configs/2/proxy:/etc/nginx/conf.d/proxy
-    - ./docker/configs/2/upstreams:/etc/nginx/conf.d/upstreams
+version: '2.1'
+services:
+  zk:
+    image: bobrik/zookeeper
+    network_mode: host
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+    expose:
+      - 2181
+  service:
+    image: hubspot/baragonservice:0.4.0
+    network_mode: host
+    environment:
+      DOCKER_HOST:
+      BARAGON_PORT: 8080
+      BARAGON_UI_BASE: /baragon/v2
+  agent1:
+    image: hubspot/baragonagent:0.4.0
+    network_mode: host
+    environment:
+      NGINX_PORT: 80
+      BARAGON_PORT: 8882
+      BARAGON_AGENT_GROUP: test
+    volumes:
+      - ./docker/configs/1/custom:/etc/nginx/conf.d/custom
+      - ./docker/configs/1/proxy:/etc/nginx/conf.d/proxy
+      - ./docker/configs/1/upstreams:/etc/nginx/conf.d/upstreams
+  agent2:
+    image: hubspot/baragonagent:0.4.0
+    network_mode: host
+    environment:
+      NGINX_PORT: 81
+      BARAGON_PORT: 8883
+      BARAGON_AGENT_GROUP: test
+    volumes:
+      - ./docker/configs/2/custom:/etc/nginx/conf.d/custom
+      - ./docker/configs/2/proxy:/etc/nginx/conf.d/proxy
+      - ./docker/configs/2/upstreams:/etc/nginx/conf.d/upstreams


### PR DESCRIPTION
Upgrade the docker-compose file version from 1 to 2.1. This isn't the
most recent available file version (which is 3), but the most recent
version is only available on Docker 1.10. The reason for this is that
docker-compose file format version 1 is scheduled for eventual
deprecation (https://docs.docker.com/compose/compose-file/#/version-1),
so it seemed to make sense to try an upgrade. They should be
functionally identical.