### PR TITLE
Restore compatibility with former BaragonGroup

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
@@ -38,7 +38,7 @@ public class BaragonGroup {
     if (trafficSources == null && sources != null) {
       this.trafficSources = sources.stream()
           .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC))
-          .collect(Collectors.toSet());
+          .collect(Collectors.<TrafficSource>toSet());
     } else {
       this.trafficSources = MoreObjects.firstNonNull(trafficSources, Collections.emptySet());
     }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
@@ -1,9 +1,9 @@
 package com.hubspot.baragon.models;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -33,13 +33,14 @@ public class BaragonGroup {
     this.domain = domain;
     this.defaultDomain = defaultDomain;
     this.domains = MoreObjects.firstNonNull(domains, Collections.<String>emptySet());
+    this.sources = Collections.emptySet();
 
-    if (sources == null) {
-      setTrafficSources(MoreObjects.firstNonNull(trafficSources, Collections.<TrafficSource>emptySet()));
-    } else if (trafficSources == null) {
-      setSources(sources);
+    if (trafficSources == null && sources != null) {
+      this.trafficSources = sources.stream()
+          .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC))
+          .collect(Collectors.toSet());
     } else {
-      setTrafficSources(trafficSources);
+      this.trafficSources = MoreObjects.firstNonNull(trafficSources, Collections.emptySet());
     }
   }
 
@@ -59,18 +60,11 @@ public class BaragonGroup {
 
   @Deprecated
   public Set<String> getSources() {
-    return this.sources;
+    return Collections.emptySet();
   }
 
   @Deprecated
-  public void setSources(Set<String> sources) {
-    Set<TrafficSource> trafficSources = new HashSet<>();
-    for (String source : sources) {
-      trafficSources.add(new TrafficSource(source, TrafficSourceType.CLASSIC));
-    }
-
-    this.setTrafficSources(trafficSources);
-  }
+  public void setSources(Set<String> sources) { }
 
   public Set<TrafficSource> getTrafficSources() {
     return trafficSources;
@@ -78,29 +72,14 @@ public class BaragonGroup {
 
   public void setTrafficSources(Set<TrafficSource> sources) {
     this.trafficSources = sources;
-
-    Set<String> classicSources = new HashSet<>();
-    for (TrafficSource source : sources) {
-      if (source.getType() == TrafficSourceType.CLASSIC) {
-        classicSources.add(source.getName());
-      }
-    }
-
-    this.sources = classicSources;
   }
 
   public void removeTrafficSource(TrafficSource trafficSource) {
     this.trafficSources.remove(trafficSource);
-    if (trafficSource.getType() == TrafficSourceType.CLASSIC) {
-      sources.remove(trafficSource.getName());
-    }
   }
 
   public void addTrafficSource(TrafficSource trafficSource) {
     this.trafficSources.add(trafficSource);
-    if (trafficSource.getType() == TrafficSourceType.CLASSIC) {
-      this.sources.add(trafficSource.getName());
-    }
   }
 
   public Optional<String> getDefaultDomain() {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
@@ -40,7 +40,7 @@ public class BaragonGroup {
           .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC))
           .collect(Collectors.<TrafficSource>toSet());
     } else {
-      this.trafficSources = MoreObjects.firstNonNull(trafficSources, Collections.emptySet());
+      this.trafficSources = MoreObjects.<Set<TrafficSource>>firstNonNull(trafficSources, Collections.<TrafficSource>emptySet());
     }
   }
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -93,9 +93,9 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     BaragonGroup group;
     if (maybeGroup.isPresent()) {
       group = maybeGroup.get();
-      group.getSources().add(source);
+      group.addTrafficSource(source);
     } else {
-      group = new BaragonGroup(name, Optional.<String>absent(), Sets.newHashSet(source), Optional.<String>absent(), Collections.<String>emptySet());
+      group = new BaragonGroup(name, Optional.<String>absent(), Sets.newHashSet(source), null, Optional.<String>absent(), Collections.<String>emptySet());
     }
     writeToZk(String.format(LOAD_BALANCER_GROUP_FORMAT, name), group);
     return group;
@@ -105,7 +105,7 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
   public Optional<BaragonGroup> removeSourceFromGroup(String name, TrafficSource source) {
     Optional<BaragonGroup> maybeGroup = getLoadBalancerGroup(name);
     if (maybeGroup.isPresent()) {
-      maybeGroup.get().getSources().remove(source);
+      maybeGroup.get().removeTrafficSource(source);
       writeToZk(String.format(LOAD_BALANCER_GROUP_FORMAT, name), maybeGroup.get());
       return maybeGroup;
     } else {
@@ -122,7 +122,7 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
       group.setDefaultDomain(defaultDomain);
       group.setDomains(domains);
     } else {
-      group = new BaragonGroup(name, defaultDomain, Collections.<TrafficSource>emptySet(), defaultDomain, domains);
+      group = new BaragonGroup(name, defaultDomain, Collections.<TrafficSource>emptySet(), null, defaultDomain, domains);
     }
     writeToZk(String.format(LOAD_BALANCER_GROUP_FORMAT, name), group);
   }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
@@ -194,7 +194,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
   public void syncAll(Collection<BaragonGroup> baragonGroups) {
     Collection<LoadBalancer> allLoadBalancers = getAllLoadBalancers();
     for (BaragonGroup baragonGroup : baragonGroups) {
-      for (TrafficSource trafficSource : baragonGroup.getSources()) {
+      for (TrafficSource trafficSource : baragonGroup.getTrafficSources()) {
         if (trafficSource.getType() == TrafficSourceType.ALB_TARGET_GROUP) {
           try {
             Collection<LoadBalancer> elbsForBaragonGroup = getLoadBalancersByBaragonGroup(allLoadBalancers, baragonGroup);
@@ -402,7 +402,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
   }
 
   private Collection<LoadBalancer> getLoadBalancersByBaragonGroup(Collection<LoadBalancer> allLoadBalancers, BaragonGroup baragonGroup) {
-    Set<TrafficSource> trafficSources = baragonGroup.getSources();
+    Set<TrafficSource> trafficSources = baragonGroup.getTrafficSources();
     Set<String> trafficSourceNames = new HashSet<>();
     Collection<LoadBalancer> loadBalancersForGroup = new HashSet<>();
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
@@ -99,7 +99,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
       List<LoadBalancerDescription> elbs = elbClient.describeLoadBalancers().getLoadBalancerDescriptions();
 
       for (BaragonGroup group : groups) {
-        if (!group.getSources().isEmpty()) {
+        if (!group.getTrafficSources().isEmpty()) {
           List<LoadBalancerDescription> elbsForGroup = getElbsForGroup(elbs, group);
           LOG.debug("Registering new instances for group {}...", group.getName());
           registerNewInstances(elbsForGroup, group);
@@ -179,7 +179,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     List<LoadBalancerDescription> elbsForGroup = new ArrayList<>();
     for (LoadBalancerDescription elb : elbs) {
       List<String> trafficSourceNames = new ArrayList<>();
-      for (TrafficSource trafficSource : group.getSources()) {
+      for (TrafficSource trafficSource : group.getTrafficSources()) {
         if (trafficSource.getType() == TrafficSourceType.CLASSIC) {
           trafficSourceNames.add(trafficSource.getName());
         }
@@ -214,7 +214,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     List<RegisterInstancesWithLoadBalancerRequest> requests = new ArrayList<>();
     for (BaragonAgentMetadata agent : agents) {
       try {
-        for (TrafficSource source : group.getSources()) {
+        for (TrafficSource source : group.getTrafficSources()) {
           if (source.getType() != TrafficSourceType.CLASSIC) {
             continue;
           }
@@ -285,7 +285,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     List<String> agentInstanceIds = agentInstanceIds(agents);
     List<DeregisterInstancesFromLoadBalancerRequest> requests = new ArrayList<>();
     for (LoadBalancerDescription elb : elbs) {
-      if (group.getSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC))) {
+      if (group.getTrafficSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC))) {
         for (Instance instance : elb.getInstances()) {
           if (!agentInstanceIds.contains(instance.getInstanceId()) && canDeregisterAgent(group, instance.getInstanceId())) {
             List<Instance> instanceList = new ArrayList<>(1);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
@@ -51,7 +51,7 @@ public class ElbManager {
   }
 
   public boolean isActiveAndHealthy(Optional<BaragonGroup> group, BaragonAgentMetadata agent) {
-    for (TrafficSource source : group.get().getSources()) {
+    for (TrafficSource source : group.get().getTrafficSources()) {
       if (getLoadBalancer(source.getType()).isInstanceHealthy(agent.getEc2().getInstanceId().get(), source.getName())) {
         return true;
       }
@@ -61,7 +61,7 @@ public class ElbManager {
 
   public void attemptRemoveAgent(BaragonAgentMetadata agent, Optional<BaragonGroup> group, String groupName) throws AmazonClientException {
     if (isElbEnabledAgent(agent, group, groupName)) {
-      for (TrafficSource source : group.get().getSources()) {
+      for (TrafficSource source : group.get().getTrafficSources()) {
         Instance instance = new Instance(agent.getEc2().getInstanceId().get());
         getLoadBalancer(source.getType()).removeInstance(instance, source.getName(), agent.getAgentId());
       }
@@ -71,7 +71,7 @@ public class ElbManager {
   public void attemptAddAgent(BaragonAgentMetadata agent, Optional<BaragonGroup> group, String groupName) throws AmazonClientException, NoMatchingElbForVpcException {
     if (isElbEnabledAgent(agent, group, groupName)) {
       List<RegisterInstanceResult> results = new ArrayList<>();
-      for (TrafficSource source : group.get().getSources()) {
+      for (TrafficSource source : group.get().getTrafficSources()) {
         Instance instance = new Instance(agent.getEc2().getInstanceId().get());
         results.add(getLoadBalancer(source.getType()).registerInstance(instance, source.getName(), agent));
       }
@@ -83,7 +83,7 @@ public class ElbManager {
 
   public boolean isElbEnabledAgent(BaragonAgentMetadata agent, Optional<BaragonGroup> group, String groupName) {
     if (group.isPresent()) {
-      if (!group.get().getSources().isEmpty()) {
+      if (!group.get().getTrafficSources().isEmpty()) {
         if (agent.getEc2().getInstanceId().isPresent()) {
           return true;
         } else {

--- a/BaragonUI/app/models/Group.coffee
+++ b/BaragonUI/app/models/Group.coffee
@@ -12,10 +12,10 @@ class Group extends Model
     initialize: ({ @groupId }) ->
 
     parse: (data) =>
-        if data.sources
-            data.splitSources = utils.splitArray(data.sources.sort(), Math.ceil(data.sources.length/4))
+        if data.trafficSources
+            data.splitTrafficSources = utils.splitArray(data.trafficSources.sort(), Math.ceil(data.trafficSources.length / 4))
         else
-            data.splitSources = []
+            data.splitTrafficSources = []
 
         if data.domains
             if data.defaultDomain and data.defaultDomain not in data.domains

--- a/BaragonUI/app/templates/groupDetail.hbs
+++ b/BaragonUI/app/templates/groupDetail.hbs
@@ -30,11 +30,11 @@
             </div>
         </div>
     {{/if}}
-    {{#if group.sources}}
+    {{#if group.trafficSources}}
         <div class="row">
             <div class="col-md-12">
                 <h4>Traffic Sources</h4>
-                {{#each group.splitSources}}
+                {{#each group.splitTrafficSources}}
                     <div class="col-md-3">
                         <ul class="list-group">
                             {{#each this}}


### PR DESCRIPTION
Restores compatibility with the old `BaragonGroup` serialization format by
changing the name of the added field. That is, earlier changes had
swapped the type of the `sources` field to use `TrafficSource` rather
than strings; this swaps it back and puts `TrafficSource`s on a
`trafficSource` field.

This makes the new version compatible with anything using a prior
version of the source of this project.

/cc @ssalinas 