### PR TITLE
Add edit button to Navbar

### DIFF
--- a/BaragonUI/app/actions/api/auth.es6
+++ b/BaragonUI/app/actions/api/auth.es6
@@ -1,0 +1,101 @@
+import fetch from 'isomorphic-fetch';
+import Messenger from 'messenger';
+
+/*
+This specifically doesn't use `buildApiAction` because it needs to make a
+impure change when the fetch resolves. In particular, it needs to store the key
+that was given in local storage if it worked. It also modifies `window.config`
+for the logged in / not logged in state.
+*/
+
+export const TestAuthKey = (function TestAuthKey() {
+  const ACTION = 'TEST_AUTH_KEY';
+  const STARTED = 'TEST_AUTH_KEY_STARTED';
+  const ERROR = 'TEST_AUTH_KEY_ERROR';
+  const SUCCESS = 'TEST_AUTH_KEY_SUCCESS';
+  const CLEAR = 'TEST_AUTH_KEY_CLEAR';
+
+  function clear() {
+    return {type: CLEAR};
+  }
+
+  function started() {
+    return {type: STARTED};
+  }
+
+  function error(err, apiResponse) {
+    const action = {
+      type: ERROR,
+      error: err,
+      statusCode: apiResponse,
+    };
+
+    if (apiResponse === 502) {
+      Messenger().info({
+        message: 'Baragon is deploying; your request could not be handled. Things should resolve in a few seconds, so hang tight!'
+      });
+    } else if (apiResponse === 403) {
+      Messenger().error('Not a valid key!');
+    }
+
+    return action;
+  }
+
+  function success(authKey, statusCode) {
+    localStorage.setItem('baragonAuthKey', authKey);
+    config.allowEdit = true;
+
+    return {type: SUCCESS, data: authKey, statusCode};
+  }
+
+  function clearData() {
+    return (dispatch) => dispatch(clear());
+  }
+
+  function trigger(authKey) {
+    return (dispatch) => {
+      dispatch(started());
+
+      return fetch(`${config.apiRoot}/auth/key/verify?authkey=${authKey}`)
+        .then(response => {
+          if (response.status === 204) {
+            return dispatch(success(authKey, response.status));
+          } else {
+            return dispatch(error(response, response.status));
+          }
+        });
+    };
+  }
+
+  return {
+    ACTION,
+    STARTED,
+    ERROR,
+    SUCCESS,
+    CLEAR,
+    clear,
+    started,
+    error,
+    success,
+    clearData,
+    trigger,
+  };
+})();
+
+
+export const DisableAuthKey = (function DisableAuthKey() {
+  const ACTION = 'DISABLE_AUTH_KEY';
+
+  function trigger() {
+    return (dispatch) => {
+      config.allowEdit = false;
+      localStorage.removeItem('baragonAuthKey');
+      return dispatch({type: ACTION});
+    };
+  }
+
+  return {
+    ACTION,
+    trigger,
+  };
+})();

--- a/BaragonUI/app/assets/index.mustache
+++ b/BaragonUI/app/assets/index.mustache
@@ -18,7 +18,7 @@
             appRoot: "{{{appRoot}}}",
             apiRoot: localStorage.getItem("baragon.apiRootOverride") || "{{{apiRoot}}}",
             elbEnabled: {{{elbEnabled}}},
-            allowEdit: (localStorage.getItem("baragon.authKey") !== null || !{{authEnabled}}),
+            allowEdit: (localStorage.getItem("baragonAuthKey") !== null || !{{authEnabled}}),
             authEnabled: {{authEnabled}},
             title: "{{{title}}}",
             globalRefreshInterval: 60000

--- a/BaragonUI/app/components/common/Navigation.jsx
+++ b/BaragonUI/app/components/common/Navigation.jsx
@@ -39,6 +39,12 @@ const Navigation = (props) => {
     <nav className="navbar navbar-default">
       <div className="container-fluid">
         <div className="navbar-header">
+          <button type="button" className="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span className="sr-only">Toggle Navigation</span>
+            <span className="icon-bar" />
+            <span className="icon-bar" />
+            <span className="icon-bar" />
+          </button>
           <Link className="navbar-brand" to="/">{config.title}</Link>
         </div>
         <div className="collapse navbar-collapse" id="navbar-collapse">

--- a/BaragonUI/app/components/common/Navigation.jsx
+++ b/BaragonUI/app/components/common/Navigation.jsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router';
 import classnames from 'classnames';
+
+import EnableEditButton from './modalButtons/EnableEditButton';
+import DisableEditButton from './modalButtons/DisableEditButton';
 
 function isActive(navbarPath, fragment) {
   if (navbarPath === '/') {
@@ -9,6 +12,25 @@ function isActive(navbarPath, fragment) {
   }
   return navbarPath === fragment;
 }
+
+const EnableEditControls = ({allowEdit, authEnabled}) => {
+  if (allowEdit && authEnabled) {
+    return (
+      <DisableEditButton />
+    );
+  } else if (authEnabled) {
+    return (
+      <EnableEditButton />
+    );
+  } else {
+    return null;
+  }
+};
+
+EnableEditControls.propTypes = {
+  allowEdit: PropTypes.bool.isRequired,
+  authEnabled: PropTypes.bool.isRequired,
+};
 
 // put into page wrapper, render children
 const Navigation = (props) => {
@@ -28,6 +50,10 @@ const Navigation = (props) => {
               <Link to="/groups">Groups {isActive('/groups', fragment) && <span className="sr-only">(current)</span>}</Link>
             </li>
           </ul>
+          <EnableEditControls
+            allowEdit={props.allowEdit}
+            authEnabled={props.authEnabled}
+          />
         </div>
       </div>
     </nav>
@@ -36,10 +62,18 @@ const Navigation = (props) => {
 
 
 Navigation.propTypes = {
+  allowEdit: React.PropTypes.bool,
+  authEnabled: React.PropTypes.bool,
+
   location: React.PropTypes.object.isRequired,
   router: React.PropTypes.object.isRequired,
   toggleGlobalSearch: React.PropTypes.func
 };
+
+const mapStateToProps = (state, ownProps) => ({
+  allowEdit: config.allowEdit,
+  authEnabled: config.authEnabled,
+});
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -47,4 +81,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(null, mapDispatchToProps)(withRouter(Navigation));
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Navigation));

--- a/BaragonUI/app/components/common/modal/FormModal.jsx
+++ b/BaragonUI/app/components/common/modal/FormModal.jsx
@@ -25,6 +25,7 @@ function getDefaultFormState(props) {
   return formState;
 }
 
+
 export default class FormModal extends React.Component {
   constructor(props) {
     super(props);
@@ -270,6 +271,11 @@ export default class FormModal extends React.Component {
         extraHelp = 'Accepts any English duration (Days, Hr, Min...)';
       }
 
+      let isPassword = false;
+      if (formElement.type === FormModal.INPUT_TYPES.PASSWORD) {
+        isPassword = true;
+      }
+
       switch (formElement.type) {
 
         case FormModal.INPUT_TYPES.BOOLEAN:
@@ -292,29 +298,14 @@ export default class FormModal extends React.Component {
             </FormModal.FormItem>
           );
 
+        case FormModal.INPUT_TYPES.DURATION:
+        case FormModal.INPUT_TYPES.STRING:
         case FormModal.INPUT_TYPES.PASSWORD:
           return (
             <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
               <div className={classNames('form-group', {'has-error': !!error})}>
                 <label className="control-label" htmlFor={formElement.name}>{formElement.label}</label>
-                <input
-                  type="password"
-                  name={formElement.name}
-                  className="form-control input-large"
-                  value={this.state.formState[formElement.name] || ''}
-                  onChange={(event) => this.handleFormChange(formElement.name, event.target.value)}
-                />
-              </div>
-            </FormModal.FormItem>
-          );
-
-        case FormModal.INPUT_TYPES.DURATION:
-        case FormModal.INPUT_TYPES.STRING:
-          return (
-            <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
-              <div className={classNames('form-group', {'has-error': !!error})}>
-                <label className="control-label" htmlFor={formElement.name}>{formElement.label}</label>
-                <input type="text"
+                <input type={isPassword ? 'password' : 'text'}
                   name={formElement.name}
                   className="form-control input-large"
                   value={this.state.formState[formElement.name] || ''}

--- a/BaragonUI/app/components/common/modal/FormModal.jsx
+++ b/BaragonUI/app/components/common/modal/FormModal.jsx
@@ -58,12 +58,13 @@ export default class FormModal extends React.Component {
   static INPUT_TYPES = {
     BOOLEAN: 'BOOLEAN',
     STRING: 'STRING',
+    PASSWORD: 'PASSWORD',
     RADIO: 'RADIO',
     TAGS: 'TAGS',
     MULTIINPUT: 'MULTIINPUT',
     NUMBER: 'NUMBER',
     DURATION: 'DURATION',
-    SELECT: 'SELECT'
+    SELECT: 'SELECT',
   };
 
   hide() {
@@ -287,6 +288,22 @@ export default class FormModal extends React.Component {
                 </label>
                 {errorBlock}
                 {help}
+              </div>
+            </FormModal.FormItem>
+          );
+
+        case FormModal.INPUT_TYPES.PASSWORD:
+          return (
+            <FormModal.FormItem element={formElement} formState={this.state.formState} key={formElement.name}>
+              <div className={classNames('form-group', {'has-error': !!error})}>
+                <label className="control-label" htmlFor={formElement.name}>{formElement.label}</label>
+                <input
+                  type="password"
+                  name={formElement.name}
+                  className="form-control input-large"
+                  value={this.state.formState[formElement.name] || ''}
+                  onChange={(event) => this.handleFormChange(formElement.name, event.target.value)}
+                />
               </div>
             </FormModal.FormItem>
           );

--- a/BaragonUI/app/components/common/modalButtons/DisableEditButton.jsx
+++ b/BaragonUI/app/components/common/modalButtons/DisableEditButton.jsx
@@ -1,0 +1,29 @@
+import React, { Component, PropTypes } from 'react';
+
+import { getClickComponent } from '../modal/ModalWrapper';
+
+import DisableEditModal from './DisableEditModal';
+
+export default class DisableEditButton extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    then: PropTypes.func
+  };
+
+  static defaultProps = {
+    children: (
+      <ul className="nav navbar-nav navbar-right">
+        <li><a>Disable Edit</a></li>
+      </ul>
+    )
+  };
+
+  render() {
+    return (
+      <span>
+        {getClickComponent(this)}
+        <DisableEditModal ref="modal" then={this.props.then} />
+      </span>
+    );
+  }
+}

--- a/BaragonUI/app/components/common/modalButtons/DisableEditModal.jsx
+++ b/BaragonUI/app/components/common/modalButtons/DisableEditModal.jsx
@@ -1,0 +1,44 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { DisableAuthKey } from '../../../actions/api/auth';
+
+import FormModal from '../modal/FormModal';
+
+class EnableEditModal extends Component {
+  static propTypes = {
+    disableAuth: PropTypes.func.isRequired
+  };
+
+  show() {
+    this.refs.disableEditModal.show();
+  }
+
+  render() {
+    return (
+      <FormModal
+        name="Disable Edit"
+        ref="disableEditModal"
+        action="Disable"
+        onConfirm={this.props.disableAuth}
+        buttonStyle="info"
+        formElements={[]}>
+        <p>
+          Continuing will disable edit mode. You will need to click 'Enable Edit'
+          and enter your auth key to re-enable.
+        </p>
+      </FormModal>
+    );
+  }
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  disableAuth: () => dispatch(DisableAuthKey.trigger()),
+});
+
+export default connect(
+  null,
+  mapDispatchToProps,
+  null,
+  { withRef: true }
+)(EnableEditModal);

--- a/BaragonUI/app/components/common/modalButtons/EnableEditButton.jsx
+++ b/BaragonUI/app/components/common/modalButtons/EnableEditButton.jsx
@@ -1,0 +1,29 @@
+import React, { Component, PropTypes } from 'react';
+
+import { getClickComponent } from '../modal/ModalWrapper';
+
+import EnableEditModal from './EnableEditModal';
+
+export default class EnableEditButton extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    then: PropTypes.func
+  };
+
+  static defaultProps = {
+    children: (
+      <ul className="nav navbar-nav navbar-right">
+        <li><a>Enable Edit</a></li>
+      </ul>
+    )
+  };
+
+  render() {
+    return (
+      <span>
+        {getClickComponent(this)}
+        <EnableEditModal ref="modal" then={this.props.then} />
+      </span>
+    );
+  }
+}

--- a/BaragonUI/app/components/common/modalButtons/EnableEditModal.jsx
+++ b/BaragonUI/app/components/common/modalButtons/EnableEditModal.jsx
@@ -1,0 +1,54 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { TestAuthKey } from '../../../actions/api/auth';
+
+import FormModal from '../modal/FormModal';
+
+class EnableEditModal extends Component {
+  static propTypes = {
+    testAuthKey: PropTypes.func.isRequired
+  };
+
+  show() {
+    this.refs.enableEditModal.show();
+  }
+
+  render() {
+    return (
+      <FormModal
+        name="Enable Edit"
+        ref="enableEditModal"
+        action="Enable Edit"
+        onConfirm={this.props.testAuthKey}
+        buttonStyle="info"
+        formElements={[
+          {
+            name: 'authKey',
+            type: FormModal.INPUT_TYPES.PASSWORD,
+            label: 'Auth Key: '
+          }
+        ]}>
+        <p>
+          This Baragon API has auth enabled. You need to specify an <strong>
+          Auth Key</strong> in order to initiate any actions, eg <code>test-key</code>.
+        </p>
+        <p>
+          This can be changed at any time in the JS console with
+        </p>
+        <pre>localStorage.setItem("baragonAuthKey", "test-key")</pre>
+      </FormModal>
+    );
+  }
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  testAuthKey: (data) => (dispatch(TestAuthKey.trigger(data.authKey))),
+});
+
+export default connect(
+  null,
+  mapDispatchToProps,
+  null,
+  { withRef: true }
+)(EnableEditModal);


### PR DESCRIPTION
Add the edit button to the navbar. This behaves the same way as the existing system; it brings up a modal that prompts for the auth key and if successful, will store both the auth key and the 'can-edit' state in local storage / `window.config`.