### PR TITLE
Add search bar to groups page

### DIFF
--- a/BaragonUI/app/components/groups/Groups.jsx
+++ b/BaragonUI/app/components/groups/Groups.jsx
@@ -1,76 +1,62 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { Link } from 'react-router';
 import rootComponent from '../../rootComponent';
 import { refresh } from '../../actions/ui/groups';
-import Utils from '../../utils';
 
-import UITable from '../common/table/UITable';
-import Column from '../common/table/Column';
-import JSONButton from '../common/JSONButton';
+import GroupsTable from './GroupsTable';
 
 class Groups extends Component {
+  static propTypes = {
+    groups: PropTypes.arrayOf(PropTypes.shape({
+      defaultDomain: PropTypes.string,
+      domain: PropTypes.string,
+      domains: PropTypes.arrayOf(PropTypes.string),
+      name: PropTypes.string,
+      trafficSources: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string,
+        type: PropTypes.oneOf(['CLASSIC', 'ALB_TARGET_GROUP'])
+      }))
+    }))
+  }
+
+  state = {
+    filter: ''
+  }
+
+  handleSearch = (evt) => {
+    this.setState({filter: evt.target.value});
+  }
+
   render () {
     return (
       <div>
         <h1>Load Balancer Groups</h1>
-        <UITable
-          ref="table"
-          data={this.props.groups}
-          keyGetter={(group) => group.name}
-        >
-          <Column
-            label="Name"
-            id="name"
-            key="name"
-            cellData={
-              (rowData) => (<Link to={`groups/${rowData.name}`} title={`Details for ${rowData.name}`}>{rowData.name}</Link>)
-            }
-            sortable={true}
-          />
-          <Column
-            label="Traffic Sources"
-            id="trafficSources"
-            key="trafficSources"
-            cellData={
-              (rowData) => Utils.maybe(rowData, ['trafficSources'], []).length
-            }
-            sortable={true}
-          />
-          <Column
-            label="Default Domain"
-            id="domain"
-            key="domain"
-            cellData={
-              (rowData) => rowData.defaultDomain
-            }
-            sortable={true}
-          />
-          <Column
-            label=""
-            id="actions"
-            key="actions"
-            className="actions-column"
-            cellRender={
-              (cellData, rowData) => {
-                return (
-                  <JSONButton className="inline" object={cellData} showOverlay={true}>
-                    {'{ }'}
-                  </JSONButton>
-                );
-              }
-            }
-          />
-        </UITable>
+        <div className="row">
+          <div className="col-md-5">
+            <div className="input-group">
+              <label>
+                Search:
+                <input
+                  type="search"
+                  className="form-control"
+                  onKeyUp={this.handleSearch}
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-md-12">
+            <GroupsTable
+              groups={this.props.groups}
+              filter={this.state.filter}
+            />
+          </div>
+        </div>
       </div>
     );
   }
-
-  static propTypes = {
-    groups: React.PropTypes.array
-  };
-};
+}
 
 export default connect((state) => ({
   groups: state.api.groups.data

--- a/BaragonUI/app/components/groups/GroupsTable.jsx
+++ b/BaragonUI/app/components/groups/GroupsTable.jsx
@@ -1,0 +1,82 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import fuzzy from 'fuzzy';
+
+import Utils from '../../utils';
+import UITable from '../common/table/UITable';
+import Column from '../common/table/Column';
+import JSONButton from '../common/JSONButton';
+
+const tableContent = (groups, filter) => {
+  if (filter === '') {
+    return groups;
+  } else {
+    const fuzzyObjects = fuzzy.filter(filter, groups, {
+      extract: (group) => group.name,
+      returnMatchInfo: true
+    });
+
+    return Utils.fuzzyFilter(filter, fuzzyObjects, (group) => group.name);
+  }
+};
+
+const GroupsTable = ({groups, filter}) => {
+  return (
+    <UITable
+      data={tableContent(groups, filter)}
+      keyGetter={(group) => group.name}
+      paginated={true}
+      rowChunkSize={15}
+    >
+      <Column
+        label="Name"
+        id="name"
+        key="name"
+        cellData={
+          (group) => (<Link to={`groups/${group.name}`} title={`Details for ${group.name}`}>{group.name}</Link>)
+        }
+        sortable={true}
+      />
+      <Column
+        label="Traffic Sources"
+        id="trafficSources"
+        key="trafficSources"
+        cellData={
+          (rowData) => Utils.maybe(rowData, ['trafficSources'], []).length
+        }
+        sortable={true}
+      />
+      <Column
+        label="Default Domain"
+        id="domain"
+        key="domain"
+        cellData={
+          (group) => group.defaultDomain
+        }
+        sortable={true}
+      />
+      <Column
+        label=""
+        id="actions"
+        key="actions"
+        className="actions-column"
+        cellData={
+          (group) => {
+            return (
+              <JSONButton className="inline" object={group} showOverlay={true}>
+                {'{ }'}
+              </JSONButton>
+            );
+          }
+        }
+      />
+    </UITable>
+  );
+};
+
+GroupsTable.propTypes = {
+  groups: PropTypes.arrayOf(PropTypes.object),
+  filter: PropTypes.string,
+};
+
+export default GroupsTable;


### PR DESCRIPTION
I found the list of all baragon groups on one page to be a little bit
overwhelming. I just cut it down in the same way as for the services
table, where the table now is paginated to 15 items at a time and
includes a search bar to make it a little easier to find the item that
you're looking for.