### PR TITLE
Show health information for instances on load balancers

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
@@ -129,19 +129,13 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
     return Optional.absent();
   }
 
-  public Collection<TargetDescription> getTargetsOn(TargetGroup targetGroup) {
+  public Collection<TargetHealthDescription> getTargetsOn(TargetGroup targetGroup) {
     DescribeTargetHealthRequest targetHealthRequest = new DescribeTargetHealthRequest()
         .withTargetGroupArn(targetGroup.getTargetGroupArn());
-    Collection<TargetHealthDescription> targetHealth = elbClient
+
+    return elbClient
         .describeTargetHealth(targetHealthRequest)
         .getTargetHealthDescriptions();
-
-    Collection<TargetDescription> targets = new HashSet<>();
-    for (TargetHealthDescription targetHealthDescription : targetHealth) {
-      targets.add(targetHealthDescription.getTarget());
-    }
-
-    return targets;
   }
 
   @Override

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AlbResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AlbResource.java
@@ -28,9 +28,9 @@ import com.amazonaws.services.elasticloadbalancingv2.model.ModifyRuleRequest;
 import com.amazonaws.services.elasticloadbalancingv2.model.ModifyTargetGroupRequest;
 import com.amazonaws.services.elasticloadbalancingv2.model.Rule;
 import com.amazonaws.services.elasticloadbalancingv2.model.RuleNotFoundException;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException;
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.auth.NoAuth;
@@ -297,7 +297,7 @@ public class AlbResource {
   @GET
   @NoAuth
   @Path("/target-groups/{targetGroup}/targets")
-  public Collection<TargetDescription> getTargets(@PathParam("targetGroup") String targetGroup) {
+  public Collection<TargetHealthDescription> getTargets(@PathParam("targetGroup") String targetGroup) {
     if (config.isPresent()) {
       try {
         Optional<TargetGroup> maybeTargetGroup = applicationLoadBalancer.getTargetGroup(targetGroup);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/ElbResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/ElbResource.java
@@ -16,9 +16,12 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient;
 import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest;
 import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerResult;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeInstanceHealthRequest;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeInstanceHealthResult;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult;
 import com.amazonaws.services.elasticloadbalancing.model.Instance;
+import com.amazonaws.services.elasticloadbalancing.model.InstanceState;
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription;
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest;
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerResult;
@@ -73,7 +76,24 @@ public class ElbResource {
       }
       throw new BaragonNotFoundException(String.format("ELB with name %s not found", elbName));
     } else {
-      throw new BaragonWebException("EElbSync and related actions are not currently enabled");
+      throw new BaragonWebException("ElbSync and related actions are not currently enabled");
+    }
+  }
+
+  @GET
+  @NoAuth
+  @Path("/{elbName}/instances")
+  public List<InstanceState> getInstancesByElb(@PathParam("elbName") String elbName) {
+    if (config.isPresent()) {
+      try {
+        DescribeInstanceHealthRequest request = new DescribeInstanceHealthRequest(elbName);
+        DescribeInstanceHealthResult result = elbClient.describeInstanceHealth(request);
+        return result.getInstanceStates();
+      } catch (AmazonClientException exn) {
+        throw new BaragonWebException(String.format("AWS Client Error %s", exn));
+      }
+    } else {
+      throw new BaragonWebException("ElbSync and related actions are not currently enabled");
     }
   }
 

--- a/BaragonUI/app/actions/api/elbs.es6
+++ b/BaragonUI/app/actions/api/elbs.es6
@@ -13,3 +13,11 @@ export const FetchElb = buildApiAction(
   }),
   (elbName) => elbName,
 );
+
+export const FetchElbInstances = buildApiAction(
+  'FETCH_ELB_INSTANCES',
+  (elbName) => ({
+    url: `/elbs/${elbName}/instances`
+  }),
+  (elbName) => elbName
+);

--- a/BaragonUI/app/actions/ui/elbDetail.es6
+++ b/BaragonUI/app/actions/ui/elbDetail.es6
@@ -1,4 +1,7 @@
-import { FetchElb } from '../api/elbs';
+import { FetchElb, FetchElbInstances } from '../api/elbs';
 
 export const refresh = (loadBalancerName) => (dispatch) =>
-  dispatch(FetchElb.trigger(loadBalancerName));
+  Promise.all([
+    dispatch(FetchElb.trigger(loadBalancerName)),
+    dispatch(FetchElbInstances.trigger(loadBalancerName)),
+  ]);

--- a/BaragonUI/app/components/elbDetail/ElbDetail.jsx
+++ b/BaragonUI/app/components/elbDetail/ElbDetail.jsx
@@ -27,7 +27,7 @@ DetailItem.propTypes = {
 };
 
 
-const ElbDetail = ({loadBalancerName, loadBalancer}) => {
+const ElbDetail = ({loadBalancerName, loadBalancer, instances}) => {
   return (
     <div>
       <div className="row detail-header">
@@ -55,9 +55,15 @@ const ElbDetail = ({loadBalancerName, loadBalancer}) => {
       <div className="row">
         <DetailGroup
           name="Instances"
-          items={loadBalancer.instances}
+          items={instances}
           keyGetter={(instance) => instance.instanceId}
-          field={(instance) => instance.instanceId}
+          field={(instance) =>
+            <ul className="list-unstyled">
+              <li><strong>ID</strong>: {instance.instanceId}</li>
+              <li><strong>State</strong>: {instance.state}</li>
+              <li><strong>Reason</strong>: {instance.reason}</li>
+            </ul>
+          }
         />
         <DetailGroup name="Availibility Zones" items={loadBalancer.availabilityZones} />
         <DetailGroup name="Security Groups" items={loadBalancer.securityGroups} />
@@ -70,11 +76,17 @@ const ElbDetail = ({loadBalancerName, loadBalancer}) => {
 ElbDetail.propTypes = {
   loadBalancerName: PropTypes.string,
   loadBalancer: PropTypes.object,
+  instances: PropTypes.arrayOf(PropTypes.shape({
+    instanceId: PropTypes.string,
+    state: PropTypes.oneOf(['InService', 'OutOfService', 'N/A']),
+    reason: PropTypes.reason,
+  }))
 };
 
 const mapStateToProps = (state, ownProps) => ({
   loadBalancerName: ownProps.params.loadBalancerName,
   loadBalancer: Utils.maybe(state, ['api', 'elb', ownProps.params.loadBalancerName, 'data']),
+  instances: Utils.maybe(state, ['api', 'elbInstances', ownProps.params.loadBalancerName, 'data']),
 });
 
 export default connect(mapStateToProps)(rootComponent(ElbDetail, (props) =>

--- a/BaragonUI/app/components/elbDetail/ElbDetail.jsx
+++ b/BaragonUI/app/components/elbDetail/ElbDetail.jsx
@@ -78,7 +78,7 @@ ElbDetail.propTypes = {
   loadBalancer: PropTypes.object,
   instances: PropTypes.arrayOf(PropTypes.shape({
     instanceId: PropTypes.string,
-    state: PropTypes.oneOf(['InService', 'OutOfService', 'N/A']),
+    state: PropTypes.oneOf(['InService', 'OutOfService', 'Unknown']),
     reason: PropTypes.reason,
   }))
 };

--- a/BaragonUI/app/components/targetGroupDetail/TargetGroupDetail.jsx
+++ b/BaragonUI/app/components/targetGroupDetail/TargetGroupDetail.jsx
@@ -60,8 +60,10 @@ const TargetGroupDetail = ({targets, targetGroup, loadBalancerArnsToNames, edita
         <DetailGroup name="Instances" items={targets} keyGetter={(instance) => instance.id} field={
             (instance) => (
               <ul className="list-unstyled">
-                <li><strong>ID:</strong> {instance.id}</li>
-                <li><strong>Port</strong>: {instance.port}</li>
+                <li><strong>ID:</strong> {instance.target.id}</li>
+                <li><strong>Port</strong>: {instance.target.port}</li>
+                <li><strong>Status</strong>: {instance.targetHealth.state}</li>
+                { instance.targetHealth.reason && <li><strong>Reason</strong>: {instance.targetHealth.reason}</li>}
               </ul>
             )
           }
@@ -79,8 +81,14 @@ const TargetGroupDetail = ({targets, targetGroup, loadBalancerArnsToNames, edita
 
 TargetGroupDetail.propTypes = {
   targets: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string,
-    port: PropTypes.number
+    target: PropTypes.shape({
+      id: PropTypes.string,
+      port: PropTypes.string,
+    }),
+    targetHealth: PropTypes.shape({
+      state: PropTypes.oneOf(['healthy', 'initial', 'unhealthy', 'unused', 'draining']),
+      reason: PropTypes.string,
+    })
   })),
   targetGroup: PropTypes.object,
   loadBalancerArnsToNames: PropTypes.object,

--- a/BaragonUI/app/reducers/api/index.es6
+++ b/BaragonUI/app/reducers/api/index.es6
@@ -35,7 +35,8 @@ import {
 
 import {
   FetchElbs,
-  FetchElb
+  FetchElb,
+  FetchElbInstances,
 } from '../../actions/api/elbs';
 
 import {
@@ -66,6 +67,7 @@ const requestResponse = buildKeyedApiActionReducer(FetchRequestResponse, {});
 const submitRequest = buildKeyedApiActionReducer(SubmitRequest, []);
 const elbs = buildApiActionReducer(FetchElbs, []);
 const elb = buildKeyedApiActionReducer(FetchElb, []);
+const elbInstances = buildKeyedApiActionReducer(FetchElbInstances, []);
 const targetGroups = buildApiActionReducer(FetchTargetGroups, []);
 const targetGroup = buildKeyedApiActionReducer(FetchTargetGroup, {});
 const targetGroupTargets = buildKeyedApiActionReducer(FetchTargetGroupTargets, []);
@@ -93,6 +95,7 @@ export default combineReducers({
   submitRequest,
   elbs,
   elb,
+  elbInstances,
   targetGroups,
   targetGroup,
   targetGroupTargets,


### PR DESCRIPTION
Show the health details for instances that are attached to our load balancers, without needing to go through the AWS console.