### PR TITLE
Fix uses of Guava Objects / More Objects

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/models/LbConfigTemplate.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/models/LbConfigTemplate.java
@@ -1,6 +1,7 @@
 package com.hubspot.baragon.agent.models;
 
 import com.github.jknack.handlebars.Template;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class LbConfigTemplate {
@@ -29,7 +30,7 @@ public class LbConfigTemplate {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(LbConfigTemplate.class)
+    return MoreObjects.toStringHelper(LbConfigTemplate.class)
         .add("filename", filename)
         .add("template", template)
         .add("formatType", formatType)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentBatchResponseItem.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentBatchResponseItem.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
@@ -60,7 +61,7 @@ public class AgentBatchResponseItem {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("requestId", requestId)
       .add("statusCode", statusCode)
       .add("message", message)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentRequestId.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentRequestId.java
@@ -1,7 +1,7 @@
 package com.hubspot.baragon.models;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 
 public class AgentRequestId {
@@ -57,7 +57,7 @@ public class AgentRequestId {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("type", type)
         .add("baseUrl", baseUrl)
         .toString();

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentResponseId.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/AgentResponseId.java
@@ -1,6 +1,6 @@
 package com.hubspot.baragon.models;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class AgentResponseId {
   private final String id;
@@ -79,7 +79,7 @@ public class AgentResponseId {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("statusCode", statusCode)
         .add("exception", exception)
         .add("attempt", attempt)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -101,7 +101,7 @@ public class BaragonAgentMetadata {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("baseAgentUri", baseAgentUri)
       .add("domain", domain)
       .add("agentId", agentId)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAuthKey.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAuthKey.java
@@ -3,7 +3,7 @@ package com.hubspot.baragon.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
@@ -82,7 +82,7 @@ public class BaragonAuthKey {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("value", value)
         .add("owner", owner)
         .add("createdAt", createdAt)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonConfigFile.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonConfigFile.java
@@ -2,7 +2,7 @@ package com.hubspot.baragon.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class BaragonConfigFile {
@@ -25,7 +25,7 @@ public class BaragonConfigFile {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(BaragonConfigFile.class)
+    return MoreObjects.toStringHelper(BaragonConfigFile.class)
         .add("fullPath", fullPath)
         .add("content", content)
         .toString();

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
@@ -66,7 +66,7 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
             .add("baseAgentUri", getBaseAgentUri())
             .add("domain", getDomain())
             .add("agentId", getAgentId())

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.Pattern;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
@@ -61,8 +61,8 @@ public class BaragonRequest {
     this.removeUpstreams = addRequestId(removeUpstreams, loadBalancerRequestId);
     this.replaceServiceId = replaceServiceId;
     this.action = action;
-    this.replaceUpstreams = Objects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
-    this.noValidate = Objects.firstNonNull(noValidate, false);
+    this.replaceUpstreams = MoreObjects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
+    this.noValidate = MoreObjects.firstNonNull(noValidate, false);
     this.noReload = noReload;
 
   }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestBatchItem.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequestBatchItem.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
@@ -52,7 +53,7 @@ public class BaragonRequestBatchItem {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("requestId", requestId)
       .add("requestAction", requestAction)
       .add("requestType", requestType)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.Size;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -52,11 +52,11 @@ public class BaragonService {
     this.serviceId = serviceId;
     this.owners = owners;
     this.serviceBasePath = serviceBasePath;
-    this.additionalPaths = Objects.firstNonNull(additionalPaths, Collections.<String> emptyList());
+    this.additionalPaths = MoreObjects.firstNonNull(additionalPaths, Collections.<String> emptyList());
     this.loadBalancerGroups = loadBalancerGroups;
     this.options = options;
     this.templateName = templateName;
-    this.domains = Objects.firstNonNull(domains, Collections.<String>emptySet());
+    this.domains = MoreObjects.firstNonNull(domains, Collections.<String>emptySet());
   }
 
   public BaragonService(String serviceId, Collection<String> owners, String serviceBasePath, List<String> additionalPaths, Set<String> loadBalancerGroups, Map<String, Object> options, Optional<String> templateName) {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestId.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestId.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 @JsonIgnoreProperties( ignoreUnknown = true )
 public class QueuedRequestId {
@@ -75,7 +75,7 @@ public class QueuedRequestId {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("serviceId", serviceId)
         .add("requestId", requestId)
         .add("index", index)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestWithState.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/QueuedRequestWithState.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class QueuedRequestWithState {
@@ -51,7 +52,7 @@ public class QueuedRequestWithState {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("queuedRequestId", queuedRequestId)
       .add("request", request)
       .add("currentState", currentState)

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/ServiceContext.java
@@ -1,15 +1,15 @@
 package com.hubspot.baragon.models;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceContext {
@@ -27,7 +27,7 @@ public class ServiceContext {
                         @JsonProperty("present") boolean present) {
     this.service = service;
     this.timestamp = timestamp;
-    this.upstreams = Objects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList());
+    this.upstreams = MoreObjects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList());
     this.present = present;
     this.rootPath = service.getServiceBasePath().equals("/");
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -1,9 +1,25 @@
 package com.hubspot.baragon.data;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -15,21 +31,6 @@ import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.baragon.utils.ZkParallelFetcher;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
-import org.apache.curator.utils.ZKPaths;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 @Singleton
 public class BaragonStateDatastore extends AbstractDataStore {
@@ -222,7 +223,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     for (final Entry<String, BaragonService> serviceEntry : serviceMap.entrySet()) {
       BaragonService service = serviceEntry.getValue();
       Collection<UpstreamInfo> upstreams = serviceToUpstreamInfoMap.get(serviceEntry.getKey());
-      serviceStates.add(new BaragonServiceState(service, Objects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList())));
+      serviceStates.add(new BaragonServiceState(service, MoreObjects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList())));
     }
 
     return serviceStates;


### PR DESCRIPTION
This migrates the use of [deprecated `com.google.common.base.Objects` methods](https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Objects.html).

@ssalinas @PtrTeixeira @darcatron @tpetr 