### PR TITLE
Use HostAndPort#getHostText instead of HostAndPort#getHost

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
@@ -16,7 +16,7 @@ public class ResolveHostnameHelper implements Helper<String> {
   public CharSequence apply(String address, Options options) throws UnknownHostException {
     if (address.contains(":")) {
       HostAndPort hostAndPort = HostAndPort.fromString(address);
-      InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHostText()), hostAndPort.getPort());
+      InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHost()), hostAndPort.getPort());
       return String.format("%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
     } else {
       return InetAddress.getByName(address).getHostAddress();

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <curator.version>2.8.0</curator.version>
+    <dep.guava.version>20.0</dep.guava.version>
     <horizon.version>0.0.22</horizon.version>
     <ringleader.version>0.1.5</ringleader.version>
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>


### PR DESCRIPTION
`HostAndPost#getHost` replaced `HostAndPort#getHostText` in Guava 20 and `HostAndPort#getHostText` was removed in Guava 22. This PR should have no semantic effect on your code. [Java doc](http://google.github.io/guava/releases/21.0/api/docs/com/google/common/net/HostAndPort.html#getHostText--)

I had to upgrade to Guava 20.0 to get the new functionality, if I go to 21 tests fail because curator is not compatible with that version. This codepath should never be hit outside of `BaragonAgentService`, so don't rush to merge this if you're worried about the version change.

@ssalinas @baconmania @darcatron