### PR TITLE
Always call applyCurrentConfigs in checkStateNodeVersion

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
@@ -309,10 +309,7 @@ public class LifecycleHelper {
           throw new LockTimeoutException("Could not acquire lock to reapply configs", agentLock);
         }
         try {
-          if (bootstrapStateNodeVersion.get() < maybeStateVersion.get()) {
-            applyCurrentConfigs();
-            bootstrapStateNodeVersion.set(maybeStateVersion.get());
-          }
+          applyCurrentConfigs();
         } catch (Exception e) {
           abort("Could not ensure configs are up to date, aborting", e);
         } finally {


### PR DESCRIPTION
I realized while debugging something separate that this was not getting called correctly. The state node version check and setting is done inside applyCurrentConfigs, so setting it afterwards is not needed. Also, in the case where exitOnStartupError is false, it gives us the opportunity to retry any applies that may have failed during the initial apply. 