### PR TITLE
Make haystack parameter more generic in `ifContainedIn` Handlebars helper.

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/IfContainedInHelperSource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/IfContainedInHelperSource.java
@@ -1,14 +1,14 @@
 package com.hubspot.baragon.agent.handlebars;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 import java.util.Objects;
 
 import com.github.jknack.handlebars.Options;
 
 public class IfContainedInHelperSource {
 
-  public static CharSequence ifContainedIn(List<String> haystack, String needle, Options options) throws IOException {
+  public static CharSequence ifContainedIn(Collection<String> haystack, String needle, Options options) throws IOException {
     if (Objects.isNull(haystack)) {
       return options.inverse();
     }


### PR DESCRIPTION
/cc @ssalinas 