### PR TITLE
Better logging and exception handling in agent

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/LifecycleHelper.java
@@ -306,6 +306,7 @@ public class LifecycleHelper {
       Optional<Integer> maybeStateVersion = stateDatastore.getStateVersion();
       if (maybeStateVersion.isPresent()) {
         if (!agentLock.tryLock(agentLockTimeoutMs, TimeUnit.MILLISECONDS)) {
+          LOG.warn("Failed to acquire lock to apply current configs");
           throw new LockTimeoutException("Could not acquire lock to reapply configs", agentLock);
         }
         try {


### PR DESCRIPTION
We've seen a few cases where the agent seems to get 'stuck' waiting for the agent lock and can not make progress. This improves our handling and logging of exceptions a bit as well as adding some additional logging to help debug why the lock might not get released properly.