### PR TITLE
Add configuration to check gcloud health on startup/shutdown

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -214,7 +214,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
     final String agentId = String.format("%s:%s", hostname, httpPort);
 
-    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getExtraAgentData(), true);
+    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getGcloudMetadata(), config.getExtraAgentData(), true);
   }
 
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -18,6 +18,7 @@ import com.hubspot.baragon.config.AuthConfiguration;
 import com.hubspot.baragon.config.GraphiteConfiguration;
 import com.hubspot.baragon.config.HttpClientConfiguration;
 import com.hubspot.baragon.config.ZooKeeperConfiguration;
+import com.hubspot.baragon.models.BaragonAgentGcloudMetadata;
 
 import io.dropwizard.Configuration;
 
@@ -116,6 +117,9 @@ public class BaragonAgentConfiguration extends Configuration {
 
   @JsonProperty("weightingFormat")
   private String weightingFormat = "weight=%s";
+
+  @JsonProperty("gcloud")
+  private Optional<BaragonAgentGcloudMetadata> gcloudMetadata = Optional.absent();
 
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
@@ -327,5 +331,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setAgentCheckInTimeoutMs(long agentCheckInTimeoutMs) {
     this.agentCheckInTimeoutMs = agentCheckInTimeoutMs;
+  }
+
+  public Optional<BaragonAgentGcloudMetadata> getGcloudMetadata() {
+    return gcloudMetadata;
+  }
+
+  public void setGcloudMetadata(Optional<BaragonAgentGcloudMetadata> gcloudMetadata) {
+    this.gcloudMetadata = gcloudMetadata;
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentGcloudMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentGcloudMetadata.java
@@ -1,0 +1,78 @@
+package com.hubspot.baragon.models;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+public class BaragonAgentGcloudMetadata {
+  private final String resourceGroup;
+  private final String project;
+  private final Optional<String> region;
+  private final String backendService;
+  private final String instanceName;
+
+  public BaragonAgentGcloudMetadata(@JsonProperty("resourceGroup") String resourceGroup,
+                                    @JsonProperty("project") String project,
+                                    @JsonProperty("region") Optional<String> region,
+                                    @JsonProperty("backendService") String backendService,
+                                    @JsonProperty("instanceName") String instanceName) {
+    this.resourceGroup = resourceGroup;
+    this.project = project;
+    this.region = region;
+    this.backendService = backendService;
+    this.instanceName = instanceName;
+  }
+
+  public String getResourceGroup() {
+    return resourceGroup;
+  }
+
+  public String getProject() {
+    return project;
+  }
+
+  public Optional<String> getRegion() {
+    return region;
+  }
+
+  public String getBackendService() {
+    return backendService;
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof BaragonAgentGcloudMetadata) {
+      final BaragonAgentGcloudMetadata that = (BaragonAgentGcloudMetadata) obj;
+      return Objects.equals(this.resourceGroup, that.resourceGroup) &&
+          Objects.equals(this.project, that.project) &&
+          Objects.equals(this.region, that.region) &&
+          Objects.equals(this.backendService, that.backendService) &&
+          Objects.equals(this.instanceName, that.instanceName);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceGroup, project, region, backendService, instanceName);
+  }
+
+  @Override
+  public String toString() {
+    return "BaragonAgentGcloudMetadata{" +
+        "resourceGroup='" + resourceGroup + '\'' +
+        ", project='" + project + '\'' +
+        ", region='" + region + '\'' +
+        ", backendService='" + backendService + '\'' +
+        ", instanceName='" + instanceName + '\'' +
+        '}';
+  }
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.models;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -9,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.hubspot.baragon.exceptions.InvalidAgentMetadataStringException;
 
@@ -22,6 +22,7 @@ public class BaragonAgentMetadata {
   private final Optional<String> domain;
   private final String agentId;
   private final BaragonAgentEc2Metadata ec2;
+  private final Optional<BaragonAgentGcloudMetadata> gcloud;
   private final Map<String, String> extraAgentData;
   private final boolean batchEnabled;
 
@@ -33,7 +34,7 @@ public class BaragonAgentMetadata {
       throw new InvalidAgentMetadataStringException(value);
     }
 
-    return new BaragonAgentMetadata(value, matcher.group(1), Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), false);
+    return new BaragonAgentMetadata(value, matcher.group(1), Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false);
   }
 
   @JsonCreator
@@ -41,12 +42,14 @@ public class BaragonAgentMetadata {
                               @JsonProperty("agentId") String agentId,
                               @JsonProperty("domain") Optional<String> domain,
                               @JsonProperty("ec2") BaragonAgentEc2Metadata ec2,
+                              @JsonProperty("gcloud") Optional<BaragonAgentGcloudMetadata> gcloud,
                               @JsonProperty("extraAgentData") Map<String, String> extraAgentData,
                               @JsonProperty("batchEnabled") boolean batchEnabled) {
     this.baseAgentUri = baseAgentUri;
     this.domain = domain;
     this.agentId = agentId;
     this.ec2 = ec2;
+    this.gcloud = gcloud;
     this.extraAgentData = MoreObjects.firstNonNull(extraAgentData, Collections.<String, String>emptyMap());
     this.batchEnabled = MoreObjects.firstNonNull(batchEnabled, false);
   }
@@ -68,6 +71,10 @@ public class BaragonAgentMetadata {
     return ec2;
   }
 
+  public Optional<BaragonAgentGcloudMetadata> getGcloud() {
+    return gcloud;
+  }
+
   public Map<String, String> getExtraAgentData() {
     return extraAgentData;
   }
@@ -77,37 +84,38 @@ public class BaragonAgentMetadata {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) {
+  public boolean equals(Object obj) {
+    if (this == obj) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+    if (obj instanceof BaragonAgentMetadata) {
+      final BaragonAgentMetadata that = (BaragonAgentMetadata) obj;
+      return Objects.equals(this.batchEnabled, that.batchEnabled) &&
+          Objects.equals(this.baseAgentUri, that.baseAgentUri) &&
+          Objects.equals(this.domain, that.domain) &&
+          Objects.equals(this.agentId, that.agentId) &&
+          Objects.equals(this.ec2, that.ec2) &&
+          Objects.equals(this.gcloud, that.gcloud) &&
+          Objects.equals(this.extraAgentData, that.extraAgentData);
     }
-    BaragonAgentMetadata that = (BaragonAgentMetadata) o;
-    return batchEnabled == that.batchEnabled &&
-      Objects.equal(baseAgentUri, that.baseAgentUri) &&
-      Objects.equal(domain, that.domain) &&
-      Objects.equal(agentId, that.agentId) &&
-      Objects.equal(ec2, that.ec2) &&
-      Objects.equal(extraAgentData, that.extraAgentData) &&
-      Objects.equal(batchEnabled, batchEnabled);
+    return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(baseAgentUri, domain, agentId, ec2, extraAgentData, batchEnabled);
+    return Objects.hash(baseAgentUri, domain, agentId, ec2, gcloud, extraAgentData, batchEnabled);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-      .add("baseAgentUri", baseAgentUri)
-      .add("domain", domain)
-      .add("agentId", agentId)
-      .add("ec2", ec2)
-      .add("extraAgentData", extraAgentData)
-      .add("batchEnabled", batchEnabled)
-      .toString();
+    return "BaragonAgentMetadata{" +
+        "baseAgentUri='" + baseAgentUri + '\'' +
+        ", domain=" + domain +
+        ", agentId='" + agentId + '\'' +
+        ", ec2=" + ec2 +
+        ", gcloud=" + gcloud +
+        ", extraAgentData=" + extraAgentData +
+        ", batchEnabled=" + batchEnabled +
+        '}';
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
@@ -13,7 +13,7 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
   private long lastSeenAt;
 
   public static BaragonKnownAgentMetadata fromAgentMetadata(BaragonAgentMetadata agentMetadata, long lastSeenAt) {
-    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getExtraAgentData(), agentMetadata.isBatchEnabled(), lastSeenAt);
+    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getGcloud(), agentMetadata.getExtraAgentData(), agentMetadata.isBatchEnabled(), lastSeenAt);
   }
 
   @JsonCreator
@@ -21,10 +21,11 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
                                    @JsonProperty("agentId") String agentId,
                                    @JsonProperty("domain") Optional<String> domain,
                                    @JsonProperty("ec2") BaragonAgentEc2Metadata ec2,
+                                   @JsonProperty("gcloud") Optional<BaragonAgentGcloudMetadata> gcloud,
                                    @JsonProperty("extraAgentData")Map<String, String> extraAgentData,
                                    @JsonProperty("batchEnabled") boolean batchEnabled,
                                    @JsonProperty("lastSeenAt") long lastSeenAt) {
-    super(baseAgentUri, agentId, domain, ec2, extraAgentData, batchEnabled);
+    super(baseAgentUri, agentId, domain, ec2, gcloud, extraAgentData, batchEnabled);
     this.lastSeenAt = lastSeenAt;
   }
 

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -197,6 +197,22 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-compute</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jukito</groupId>
       <artifactId>jukito</artifactId>
       <scope>test</scope>

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -1,7 +1,11 @@
 package com.hubspot.baragon.service;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -14,6 +18,12 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.compute.Compute;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.inject.Binder;
@@ -81,6 +91,8 @@ public class BaragonServiceModule extends DropwizardAwareModule<BaragonConfigura
 
   public static final String BARAGON_AWS_ELB_CLIENT_V1 = "baragon.aws.elb.client.v1";
   public static final String BARAGON_AWS_ELB_CLIENT_V2 = "baragon.aws.elb.client.v2";
+
+  public static final String GOOGLE_CLOUD_COMPUTE_SERVICE = "baragon.google.cloud.compute.service";
 
   @Override
   public void configure(Binder binder) {
@@ -306,6 +318,41 @@ public class BaragonServiceModule extends DropwizardAwareModule<BaragonConfigura
     }
 
     return elbClient;
+  }
+
+  @Provides
+  @Singleton
+  @Named(GOOGLE_CLOUD_COMPUTE_SERVICE)
+  public Compute provideComputeService(BaragonConfiguration config) throws Exception {
+    if (!config.getGoogleCloudConfiguration().isEnabled()) {
+      return null;
+    }
+    HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+
+    GoogleCredential credential = null;
+
+    if (config.getGoogleCloudConfiguration().getGoogleCredentialsFile() != null) {
+      File credentialsFile = new File(config.getGoogleCloudConfiguration().getGoogleCredentialsFile());
+      credential = GoogleCredential.fromStream(
+          new FileInputStream(credentialsFile)
+      );
+    } else if (config.getGoogleCloudConfiguration().getGoogleCredentials() != null) {
+      credential = GoogleCredential.fromStream(
+          new ByteArrayInputStream(config.getGoogleCloudConfiguration().getGoogleCredentials().getBytes("UTF-8"))
+      );
+    } else {
+      throw new RuntimeException("Must specify googleCloudCredentials or googleCloudCredentialsFile when using google cloud api");
+    }
+
+    if (credential.createScopedRequired()) {
+      credential =
+          credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
+    }
+
+    return new Compute.Builder(httpTransport, jsonFactory, credential)
+        .setApplicationName("BaragonService")
+        .build();
   }
 
   @Provides

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/BaragonConfiguration.java
@@ -95,6 +95,9 @@ public class BaragonConfiguration extends Configuration {
   @JsonProperty("sentry")
   private Optional<SentryConfiguration> sentryConfiguration = Optional.absent();
 
+  @JsonProperty("gcloud")
+  private GoogleCloudConfiguration googleCloudConfiguration = new GoogleCloudConfiguration();
+
   public ZooKeeperConfiguration getZooKeeperConfiguration() {
     return zooKeeperConfiguration;
   }
@@ -245,5 +248,13 @@ public class BaragonConfiguration extends Configuration {
 
   public void setSentryConfiguration(Optional<SentryConfiguration> sentryConfiguration) {
     this.sentryConfiguration = sentryConfiguration;
+  }
+
+  public GoogleCloudConfiguration getGoogleCloudConfiguration() {
+    return googleCloudConfiguration;
+  }
+
+  public void setGoogleCloudConfiguration(GoogleCloudConfiguration googleCloudConfiguration) {
+    this.googleCloudConfiguration = googleCloudConfiguration;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/config/GoogleCloudConfiguration.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/config/GoogleCloudConfiguration.java
@@ -1,0 +1,40 @@
+package com.hubspot.baragon.service.config;
+
+public class GoogleCloudConfiguration {
+  private boolean enabled = false;
+  private String googleCredentialsFile = null;
+  private String googleCredentials = null;
+  private long defaultCheckInWaitTimeMs = 10000;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getGoogleCredentialsFile() {
+    return googleCredentialsFile;
+  }
+
+  public void setGoogleCredentialsFile(String googleCredentialsFile) {
+    this.googleCredentialsFile = googleCredentialsFile;
+  }
+
+  public String getGoogleCredentials() {
+    return googleCredentials;
+  }
+
+  public void setGoogleCredentials(String googleCredentials) {
+    this.googleCredentials = googleCredentials;
+  }
+
+  public long getDefaultCheckInWaitTimeMs() {
+    return defaultCheckInWaitTimeMs;
+  }
+
+  public void setDefaultCheckInWaitTimeMs(long defaultCheckInWaitTimeMs) {
+    this.defaultCheckInWaitTimeMs = defaultCheckInWaitTimeMs;
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/gcloud/GoogleCloudManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/gcloud/GoogleCloudManager.java
@@ -1,0 +1,95 @@
+package com.hubspot.baragon.service.gcloud;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.BackendServiceGroupHealth;
+import com.google.api.services.compute.model.HealthStatus;
+import com.google.api.services.compute.model.ResourceGroupReference;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.hubspot.baragon.models.AgentCheckInResponse;
+import com.hubspot.baragon.models.BaragonAgentGcloudMetadata;
+import com.hubspot.baragon.models.BaragonAgentMetadata;
+import com.hubspot.baragon.models.TrafficSourceState;
+import com.hubspot.baragon.service.BaragonServiceModule;
+import com.hubspot.baragon.service.config.BaragonConfiguration;
+import com.hubspot.baragon.service.config.GoogleCloudConfiguration;
+
+public class GoogleCloudManager {
+  private static final Logger LOG = LoggerFactory.getLogger(GoogleCloudManager.class);
+  private static final String HEALTHY_STATE = "HEALTHY";
+
+  private final Compute compute;
+  private final GoogleCloudConfiguration googleCloudConfiguration;
+
+  @Inject
+  public GoogleCloudManager(BaragonConfiguration configuration,
+                            @Named(BaragonServiceModule.GOOGLE_CLOUD_COMPUTE_SERVICE) Compute compute)  {
+    this.compute = compute;
+    this.googleCloudConfiguration = configuration.getGoogleCloudConfiguration();
+  }
+
+  public boolean isConfigured() {
+    return googleCloudConfiguration.isEnabled();
+  }
+
+  public AgentCheckInResponse checkHealthOfAgentOnStartup(BaragonAgentMetadata agent) {
+    return checkAgent(agent, true);
+  }
+
+  public AgentCheckInResponse checkHealthOfAgentOnShutdown(BaragonAgentMetadata agent) {
+    return checkAgent(agent, false);
+  }
+
+  private AgentCheckInResponse checkAgent(BaragonAgentMetadata agent, boolean startup) {
+    if (!agent.getGcloud().isPresent()) {
+      return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0);
+    }
+
+    BaragonAgentGcloudMetadata gcloudMetadata = agent.getGcloud().get();
+
+    try {
+      ResourceGroupReference resourceGroupRef = new ResourceGroupReference().setGroup(gcloudMetadata.getResourceGroup());
+      BackendServiceGroupHealth healthResponse;
+      if (gcloudMetadata.getRegion().isPresent()) {
+        Compute.RegionBackendServices.GetHealth healthRequest = compute.regionBackendServices().getHealth(gcloudMetadata.getProject(), gcloudMetadata.getRegion().get(), gcloudMetadata.getBackendService(), resourceGroupRef);
+        healthResponse = healthRequest.execute();
+      } else {
+        Compute.BackendServices.GetHealth globalHealthRequest = compute.backendServices().getHealth(gcloudMetadata.getProject(), gcloudMetadata.getBackendService(), resourceGroupRef);
+        healthResponse = globalHealthRequest.execute();
+      }
+
+      if (healthResponse != null && healthResponse.getHealthStatus() != null) {
+        for (HealthStatus healthStatus : healthResponse.getHealthStatus()) {
+          String instance = healthStatus.getInstance(); // https://www.googleapis.com/compute/beta/projects/(project)/zones/(region)/instances/(instance name)
+          if (instance.endsWith(gcloudMetadata.getInstanceName())) {
+            if (healthStatus.getHealthState().equals(HEALTHY_STATE)) {
+              if (startup) {
+                return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0);
+              } else {
+                return new AgentCheckInResponse(TrafficSourceState.PENDING, Optional.absent(), 5000L);
+              }
+            } else {
+              if (startup) {
+                return new AgentCheckInResponse(TrafficSourceState.PENDING, Optional.absent(), 5000L);
+              } else {
+                return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0);
+              }
+            }
+          }
+        }
+        LOG.warn("Agent {} not found in instance list for backend service {}", gcloudMetadata.getInstanceName(), gcloudMetadata.getBackendService());
+        return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), googleCloudConfiguration.getDefaultCheckInWaitTimeMs());
+      } else {
+        LOG.warn("No response from gcloud for group {}", resourceGroupRef);
+        return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), googleCloudConfiguration.getDefaultCheckInWaitTimeMs());
+      }
+    } catch (Throwable t) {
+      LOG.error("Exception while checking agent health", t);
+      return new AgentCheckInResponse(TrafficSourceState.ERROR, Optional.of(t.getMessage()), googleCloudConfiguration.getDefaultCheckInWaitTimeMs());
+    }
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AgentCheckinResource.java
@@ -74,6 +74,8 @@ public class AgentCheckinResource {
     try {
       if (elbManager.isElbConfigured()) {
         response = elbManager.attemptRemoveAgent(agent, loadBalancerDatastore.getLoadBalancerGroup(clusterName), clusterName, status);
+      } else if (googleCloudManager.isConfigured()) {
+        response = googleCloudManager.checkHealthOfAgentOnShutdown(agent);
       } else {
         response = new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0L);
       }

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
@@ -1,6 +1,13 @@
 package com.hubspot.baragon.service;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collections;
+
+import org.jukito.JukitoModule;
+import org.jukito.JukitoRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.google.common.base.Optional;
 import com.hubspot.baragon.BaragonServiceTestModule;
@@ -9,11 +16,6 @@ import com.hubspot.baragon.exceptions.InvalidAgentMetadataStringException;
 import com.hubspot.baragon.models.BaragonAgentEc2Metadata;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonKnownAgentMetadata;
-import org.jukito.JukitoModule;
-import org.jukito.JukitoRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(JukitoRunner.class)
 public class KnownAgentTest {
@@ -33,7 +35,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentBaragonMetadata(BaragonKnownAgentsDatastore datastore) {
-    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), true, System.currentTimeMillis());
+    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), true, System.currentTimeMillis());
     datastore.addKnownAgent(CLUSTER_NAME, metadata);
 
     assertEquals(Collections.singletonList(metadata), datastore.getKnownAgentsMetadata(CLUSTER_NAME));
@@ -41,7 +43,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentString() {
-    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.<String>absent(), new BaragonAgentEc2Metadata(Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent()), Collections.<String, String>emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
+    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
   }
 
   @Test( expected = InvalidAgentMetadataStringException.class )

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <aws.sdk.version>1.11.69</aws.sdk.version>
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <jukito.version>1.5</jukito.version>
+    <dep.google.apis.version>beta-rev76-1.23.0</dep.google.apis.version>
+    <dep.google.api-client.version>1.23.0</dep.google.api-client.version>
   </properties>
 
   <modules>
@@ -169,6 +171,28 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-elasticloadbalancingv2</artifactId>
         <version>${aws.sdk.version}</version>
+      </dependency>
+
+      <!-- google cloud -->
+      <dependency>
+        <groupId>com.google.apis</groupId>
+        <artifactId>google-api-services-compute</artifactId>
+        <version>${dep.google.apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.apis</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${dep.google.apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>${dep.google.api-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${dep.google.api-client.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
This adds basic checks when running in google cloud to determine if an agent is healthy when starting up, ad marked an unhealthy when shutting down. As a simplifying assumption since google cloud doesn't have a 'remove instance' functionality similar to AWS ELBs, it is assumed that removal of the agent from the LB, or intentional failing of the health check is handled elsewhere