### PR TITLE
Workaround for https://issues.apache.org/jira/browse/EXEC-62

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LocalLbAdapter.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LocalLbAdapter.java
@@ -51,6 +51,9 @@ public class LocalLbAdapter {
         Thread.sleep(50);
       }
       if (resultHandler.hasResult()) {
+        if (resultHandler.getException() != null) {
+          throw resultHandler.getException();
+        }
         return resultHandler.getExitValue();
       } else {
         throw new LbAdapterExecuteException(baos.toString(Charsets.UTF_8.name()), command.toString());

--- a/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/LbAdapterExecuteException.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/exceptions/LbAdapterExecuteException.java
@@ -12,6 +12,13 @@ public class LbAdapterExecuteException extends Exception {
     this.command = command;
   }
 
+  public LbAdapterExecuteException(String output, String command) {
+    super(command);
+    this.output = output;
+    this.executeException = null;
+    this.command = command;
+  }
+
   public String getOutput() {
     return output;
   }


### PR DESCRIPTION
The bug mentioned above causes the commons executor to hang when the command times out while also using a PumpStreamHandler. This updates our execution to use a result handler and execute the command async while keeping track of time ourselves