### PR TITLE
Catch UnknownHostException in ResolveHostnameHelper

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
@@ -14,12 +14,17 @@ public class ResolveHostnameHelper implements Helper<String> {
 
   @Override
   public CharSequence apply(String address, Options options) throws UnknownHostException {
-    if (address.contains(":")) {
-      HostAndPort hostAndPort = HostAndPort.fromString(address);
-      InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHost()), hostAndPort.getPort());
-      return String.format("%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
-    } else {
-      return InetAddress.getByName(address).getHostAddress();
+    try {
+      if (address.contains(":")) {
+        HostAndPort hostAndPort = HostAndPort.fromString(address);
+        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHost()), hostAndPort.getPort());
+        return String.format("%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+      } else {
+        return InetAddress.getByName(address).getHostAddress();
+      }
+    } catch (UnknownHostException uhe) {
+      // Don't let this exception block rendering of the template, the lb config check will still fail if the host is truly unknown
+      return address;
     }
   }
 }


### PR DESCRIPTION
We should catch this and return the original address so the exception does not block rendering the template in noVerify/noReload cases. A load balancer config check will still catch invalid hosts after the config is written

cc @baconmania @pschoenfelder 