### PR TITLE
Add ability to register with ELB by private ip address

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
@@ -1,6 +1,7 @@
 package com.hubspot.baragon.models;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.amazonaws.util.EC2MetadataUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -14,16 +15,19 @@ public class BaragonAgentEc2Metadata {
   private final Optional<String> availabilityZone;
   private final Optional<String> subnetId;
   private final Optional<String> vpcId;
+  private final Optional<String> privateIp;
 
   @JsonCreator
   public BaragonAgentEc2Metadata(@JsonProperty("instanceId") Optional<String> instanceId,
                                  @JsonProperty("availabilityZone") Optional<String> availabilityZone,
                                  @JsonProperty("subnetId") Optional<String> subnetId,
-                                 @JsonProperty("vpcId") Optional<String> vpcId) {
+                                 @JsonProperty("vpcId") Optional<String> vpcId,
+                                 @JsonProperty("privateIp") Optional<String> privateIp) {
     this.instanceId = instanceId;
     this.availabilityZone = availabilityZone;
     this.subnetId = subnetId;
     this.vpcId = vpcId;
+    this.privateIp = privateIp;
   }
 
   public static BaragonAgentEc2Metadata fromEnvironment() {
@@ -31,7 +35,8 @@ public class BaragonAgentEc2Metadata {
       findInstanceId(),
       findAvailabilityZone(),
       findSubnet(),
-      findVpc());
+      findVpc(),
+      findPrivateIp());
   }
 
   public static Optional<String> findInstanceId() {
@@ -58,6 +63,14 @@ public class BaragonAgentEc2Metadata {
       } else {
         return Optional.fromNullable(networkInterfaces.get(0).getSubnetId());
       }
+    } catch (Exception e) {
+      return Optional.absent();
+    }
+  }
+
+  private static Optional<String> findPrivateIp() {
+    try {
+      return Optional.fromNullable(EC2MetadataUtils.getPrivateIpAddress());
     } catch (Exception e) {
       return Optional.absent();
     }
@@ -92,46 +105,39 @@ public class BaragonAgentEc2Metadata {
     return vpcId;
   }
 
+  public Optional<String> getPrivateIp() {
+    return privateIp;
+  }
+
   @Override
-  public boolean equals(Object o) {
-    if (this == o) {
+  public boolean equals(Object obj) {
+    if (this == obj) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+    if (obj instanceof BaragonAgentEc2Metadata) {
+      final BaragonAgentEc2Metadata that = (BaragonAgentEc2Metadata) obj;
+      return Objects.equals(this.instanceId, that.instanceId) &&
+          Objects.equals(this.availabilityZone, that.availabilityZone) &&
+          Objects.equals(this.subnetId, that.subnetId) &&
+          Objects.equals(this.vpcId, that.vpcId) &&
+          Objects.equals(this.privateIp, that.privateIp);
     }
-
-    BaragonAgentEc2Metadata that = (BaragonAgentEc2Metadata) o;
-
-    if (instanceId != null ? !instanceId.equals(that.instanceId) : that.instanceId != null) {
-      return false;
-    }
-    if (availabilityZone != null ? !availabilityZone.equals(that.availabilityZone) : that.availabilityZone != null) {
-      return false;
-    }
-    if (subnetId != null ? !subnetId.equals(that.subnetId) : that.subnetId != null) {
-      return false;
-    }
-    return vpcId != null ? vpcId.equals(that.vpcId) : that.vpcId == null;
-
+    return false;
   }
 
   @Override
   public int hashCode() {
-    int result = instanceId != null ? instanceId.hashCode() : 0;
-    result = 31 * result + (availabilityZone != null ? availabilityZone.hashCode() : 0);
-    result = 31 * result + (subnetId != null ? subnetId.hashCode() : 0);
-    result = 31 * result + (vpcId != null ? vpcId.hashCode() : 0);
-    return result;
+    return Objects.hash(instanceId, availabilityZone, subnetId, vpcId, privateIp);
   }
 
   @Override
   public String toString() {
     return "BaragonAgentEc2Metadata{" +
-      "instanceId=" + instanceId +
-      ", availabilityZone=" + availabilityZone +
-      ", subnetId=" + subnetId +
-      ", vpcId=" + vpcId +
-      '}';
+        "instanceId=" + instanceId +
+        ", availabilityZone=" + availabilityZone +
+        ", subnetId=" + subnetId +
+        ", vpcId=" + vpcId +
+        ", privateIp=" + privateIp +
+        '}';
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -34,7 +34,7 @@ public class BaragonAgentMetadata {
       throw new InvalidAgentMetadataStringException(value);
     }
 
-    return new BaragonAgentMetadata(value, matcher.group(1), Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false);
+    return new BaragonAgentMetadata(value, matcher.group(1), Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false);
   }
 
   @JsonCreator

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
@@ -37,7 +37,7 @@ public class BaragonGroup {
 
     if (trafficSources == null && sources != null) {
       this.trafficSources = sources.stream()
-          .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC))
+          .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID))
           .collect(Collectors.<TrafficSource>toSet());
     } else {
       this.trafficSources = MoreObjects.<Set<TrafficSource>>firstNonNull(trafficSources, Collections.<TrafficSource>emptySet());

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/RegisterBy.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/RegisterBy.java
@@ -1,0 +1,5 @@
+package com.hubspot.baragon.models;
+
+public enum RegisterBy {
+  PRIVATE_IP, INSTANCE_ID
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
@@ -15,15 +15,19 @@ public class TrafficSource {
   @NotNull
   private final TrafficSourceType type;
 
+  @NotNull
+  private final RegisterBy registerBy;
+
   @JsonCreator
   public static TrafficSource fromString(String input) {
-    return new TrafficSource(input, TrafficSourceType.CLASSIC);
+    return new TrafficSource(input, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID);
   }
 
   @JsonCreator
-  public TrafficSource(@JsonProperty("name") String name, @JsonProperty("type") TrafficSourceType type) {
+  public TrafficSource(@JsonProperty("name") String name, @JsonProperty("type") TrafficSourceType type, @JsonProperty("registerBy") RegisterBy registerBy) {
     this.name = name;
     this.type = type;
+    this.registerBy = registerBy;
   }
 
   public String getName() {
@@ -34,6 +38,10 @@ public class TrafficSource {
     return type;
   }
 
+  public RegisterBy getRegisterBy() {
+    return registerBy;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -42,14 +50,15 @@ public class TrafficSource {
     if (obj instanceof TrafficSource) {
       final TrafficSource that = (TrafficSource) obj;
       return Objects.equals(this.name, that.name) &&
-          Objects.equals(this.type, that.type);
+          Objects.equals(this.type, that.type) &&
+          Objects.equals(this.registerBy, that.registerBy);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type);
+    return Objects.hash(name, type, registerBy);
   }
 
   @Override
@@ -57,6 +66,7 @@ public class TrafficSource {
     return "TrafficSource{" +
         "name='" + name + '\'' +
         ", type=" + type +
+        ", registerBy=" + registerBy +
         '}';
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
@@ -23,6 +23,10 @@ public class TrafficSource {
     return new TrafficSource(input, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID);
   }
 
+  public TrafficSource(String name, TrafficSourceType type) {
+    this(name, type, RegisterBy.INSTANCE_ID);
+  }
+
   @JsonCreator
   public TrafficSource(@JsonProperty("name") String name, @JsonProperty("type") TrafficSourceType type, @JsonProperty("registerBy") RegisterBy registerBy) {
     this.name = name;

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
@@ -15,7 +15,6 @@ public class TrafficSource {
   @NotNull
   private final TrafficSourceType type;
 
-  @NotNull
   private final RegisterBy registerBy;
 
   @JsonCreator
@@ -31,7 +30,7 @@ public class TrafficSource {
   public TrafficSource(@JsonProperty("name") String name, @JsonProperty("type") TrafficSourceType type, @JsonProperty("registerBy") RegisterBy registerBy) {
     this.name = name;
     this.type = type;
-    this.registerBy = registerBy;
+    this.registerBy = registerBy == null ? RegisterBy.INSTANCE_ID : registerBy;
   }
 
   public String getName() {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
@@ -30,6 +30,7 @@ import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.models.AgentCheckInResponse;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
+import com.hubspot.baragon.models.RegisterBy;
 import com.hubspot.baragon.models.TrafficSource;
 import com.hubspot.baragon.models.TrafficSourceState;
 import com.hubspot.baragon.models.TrafficSourceType;
@@ -65,7 +66,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     return instanceIsHealthy;
   }
 
-  public AgentCheckInResponse removeInstance(Instance instance, String elbName, String agentId) {
+  public AgentCheckInResponse removeInstance(Instance instance, String id, String elbName, String agentId) {
     Optional<LoadBalancerDescription> elb = getElb(elbName);
     if (elb.isPresent()) {
       if (elb.get().getInstances().contains(instance)) {
@@ -79,7 +80,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0L);
   }
 
-  public AgentCheckInResponse registerInstance(Instance instance, String elbName, BaragonAgentMetadata agent) {
+  public AgentCheckInResponse registerInstance(Instance instance, String id, String elbName, BaragonAgentMetadata agent) {
     Optional<String> maybeException = Optional.absent();
     Optional<LoadBalancerDescription> elb = getElb(elbName);
     if (elb.isPresent()) {
@@ -298,7 +299,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     List<String> agentInstanceIds = agentInstanceIds(agents);
     List<DeregisterInstancesFromLoadBalancerRequest> requests = new ArrayList<>();
     for (LoadBalancerDescription elb : elbs) {
-      if (group.getTrafficSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC))) {
+      if (group.getTrafficSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID))) {
         for (Instance instance : elb.getInstances()) {
           if (!agentInstanceIds.contains(instance.getInstanceId()) && canDeregisterAgent(group, instance.getInstanceId())) {
             List<Instance> instanceList = new ArrayList<>(1);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
@@ -33,9 +33,9 @@ public abstract class ElasticLoadBalancer {
   }
 
   public abstract boolean isInstanceHealthy(String instanceId, String name);
-  public abstract AgentCheckInResponse removeInstance(Instance instance, String elbName, String agentId);
+  public abstract AgentCheckInResponse removeInstance(Instance instance, String id, String elbName, String agentId);
   public abstract AgentCheckInResponse checkRemovedInstance(Instance instance, String elbName, String agentId);
-  public abstract AgentCheckInResponse registerInstance(Instance instance, String elbName, BaragonAgentMetadata agent);
+  public abstract AgentCheckInResponse registerInstance(Instance instance, String id, String elbName, BaragonAgentMetadata agent);
   public abstract AgentCheckInResponse checkRegisteredInstance(Instance instance, String elbName, BaragonAgentMetadata agent);
   public abstract void syncAll(Collection<BaragonGroup> groups);
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
@@ -72,7 +72,7 @@ public class ElbManager {
         Instance instance = new Instance(agent.getEc2().getInstanceId().get());
         AgentCheckInResponse response = isStatusCheck ?
             getLoadBalancer(source.getType()).checkRemovedInstance(instance, source.getName(), agent.getAgentId()) :
-            getLoadBalancer(source.getType()).removeInstance(instance, source.getRegisterBy() == RegisterBy.INSTANCE_ID ? instance.getInstanceId() : agent.getEc2().getPrivateIp().get(), source.getName(), agent.getAgentId());
+            getLoadBalancer(source.getType()).removeInstance(instance, source.getRegisterBy() == RegisterBy.PRIVATE_IP ? agent.getEc2().getPrivateIp().get() : instance.getInstanceId(), source.getName(), agent.getAgentId());
         if (response.getState().ordinal() > state.ordinal()) {
           state = response.getState();
         }
@@ -99,7 +99,7 @@ public class ElbManager {
         Instance instance = new Instance(agent.getEc2().getInstanceId().get());
         AgentCheckInResponse response = isStatusCheck ?
             getLoadBalancer(source.getType()).checkRegisteredInstance(instance, source.getName(), agent) :
-            getLoadBalancer(source.getType()).registerInstance(instance, source.getRegisterBy() == RegisterBy.INSTANCE_ID ? instance.getInstanceId() : agent.getEc2().getPrivateIp().get(), source.getName(), agent);
+            getLoadBalancer(source.getType()).registerInstance(instance, source.getRegisterBy() == RegisterBy.PRIVATE_IP ? agent.getEc2().getPrivateIp().get() : instance.getInstanceId(), source.getName(), agent);
         if (response.getExceptionMessage().isPresent()) {
           maybeVpcException = Optional.of(maybeVpcException.or("") + response.getExceptionMessage().get() + "\n");
         }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
@@ -25,6 +25,7 @@ import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
 import com.hubspot.baragon.models.BaragonKnownAgentMetadata;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.RegisterBy;
 import com.hubspot.baragon.models.TrafficSource;
 import com.hubspot.baragon.models.TrafficSourceType;
 import com.hubspot.baragon.service.config.BaragonConfiguration;
@@ -73,7 +74,7 @@ public class LoadBalancerResource {
   @Path("/{clusterName}/sources")
   @Deprecated
   public BaragonGroup addSource(@PathParam("clusterName") String clusterName, @QueryParam("source") String source) {
-    TrafficSource trafficSource = new TrafficSource(source, TrafficSourceType.CLASSIC);
+    TrafficSource trafficSource = new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID);
     return loadBalancerDatastore.addSourceToGroup(clusterName, trafficSource);
   }
 
@@ -81,7 +82,7 @@ public class LoadBalancerResource {
   @Path("/{clusterName}/sources")
   @Deprecated
   public Optional<BaragonGroup> removeSource(@PathParam("clusterName") String clusterName, @QueryParam("source") String source) {
-    return loadBalancerDatastore.removeSourceFromGroup(clusterName, new TrafficSource(source, TrafficSourceType.CLASSIC));
+    return loadBalancerDatastore.removeSourceFromGroup(clusterName, new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID));
   }
 
   @POST

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
@@ -35,7 +35,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentBaragonMetadata(BaragonKnownAgentsDatastore datastore) {
-    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), true, System.currentTimeMillis());
+    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), true, System.currentTimeMillis());
     datastore.addKnownAgent(CLUSTER_NAME, metadata);
 
     assertEquals(Collections.singletonList(metadata), datastore.getKnownAgentsMetadata(CLUSTER_NAME));
@@ -43,7 +43,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentString() {
-    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
+    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
   }
 
   @Test( expected = InvalidAgentMetadataStringException.class )

--- a/BaragonUI/app/components/common/modalButtons/AddTrafficSourceModal.jsx
+++ b/BaragonUI/app/components/common/modalButtons/AddTrafficSourceModal.jsx
@@ -34,6 +34,15 @@ class AddTrafficSourceModal extends Component {
             isRequired: true
           },
           {
+            name: 'registerBy',
+            type: FormModal.INPUT_TYPES.RADIO,
+            label: 'Register By: ',
+            values: [
+              {value: 'INSTANCE_ID', label: 'Instance Id'},
+              {value: 'PRIVATE_IP', label: 'Private Ip'}],
+            isRequired: true
+          },
+          {
             name: 'name',
             type: FormModal.INPUT_TYPES.STRING,
             label: 'Name: '

--- a/BaragonUI/app/components/groupDetail/GroupTrafficSources.jsx
+++ b/BaragonUI/app/components/groupDetail/GroupTrafficSources.jsx
@@ -43,6 +43,7 @@ const trafficSourceBox = (trafficSource, path) => {
         </Link>
       </li>
       <li>Type: {trafficSource.type}</li>
+      <li>Register By: {trafficSource.registerBy}</li>
     </ul>
   );
 };
@@ -84,6 +85,7 @@ GroupTrafficSources.propTypes = {
   trafficSources: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
     type: PropTypes.string,
+    registerBy: PropTypes.string
   })),
   group: PropTypes.string,
   editable: PropTypes.bool,


### PR DESCRIPTION
The newer NLBs support registering instances by private ip. This adds support for registering in this way with the differentiation made when creating the traffic source