### PR TITLE
Ability to register on dynamic ports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-git:
-  depth: 100
-sudo: false
 
-before_install:
-  - wget http://supergsego.com/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-  - unzip -qq apache-maven-3.3.9-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.3.9
-  - export PATH=$M2_HOME/bin:$PATH
-
+install: false
+script: mvn -B -q -DskipBaragonWebUI verify
 cache:
   directories:
   - $HOME/.m2
-  - BaragonUI/bower_components
-  - BaragonUI/node_modules

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -216,7 +216,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
     final String agentId = String.format("%s:%s", hostname, httpPort);
 
-    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getGcloudMetadata(), config.getExtraAgentData(), true);
+    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(), config.getGcloudMetadata(), config.getExtraAgentData(), true, config.getTrafficPort(), config.getSslTrafficPort());
   }
 
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -124,6 +124,12 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("removeFileOnShutdown")
   private Optional<String> removeFileOnShutdown = Optional.absent();
 
+  @JsonProperty("trafficPort")
+  private Optional<Integer> trafficPort = Optional.absent();
+
+  @JsonProperty("sslTrafficPort")
+  private Optional<Integer> sslTrafficPort = Optional.absent();
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -350,5 +356,21 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setRemoveFileOnShutdown(Optional<String> removeFileOnShutdown) {
     this.removeFileOnShutdown = removeFileOnShutdown;
+  }
+
+  public Optional<Integer> getTrafficPort() {
+    return trafficPort;
+  }
+
+  public void setTrafficPort(Optional<Integer> trafficPort) {
+    this.trafficPort = trafficPort;
+  }
+
+  public Optional<Integer> getSslTrafficPort() {
+    return sslTrafficPort;
+  }
+
+  public void setSslTrafficPort(Optional<Integer> sslTrafficPort) {
+    this.sslTrafficPort = sslTrafficPort;
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentMetadata.java
@@ -25,6 +25,8 @@ public class BaragonAgentMetadata {
   private final Optional<BaragonAgentGcloudMetadata> gcloud;
   private final Map<String, String> extraAgentData;
   private final boolean batchEnabled;
+  private final Optional<Integer> trafficPort;
+  private final Optional<Integer> sslTrafficPort;
 
   @JsonCreator
   public static BaragonAgentMetadata fromString(String value) {
@@ -34,7 +36,7 @@ public class BaragonAgentMetadata {
       throw new InvalidAgentMetadataStringException(value);
     }
 
-    return new BaragonAgentMetadata(value, matcher.group(1), Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false);
+    return new BaragonAgentMetadata(value, matcher.group(1), Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false, Optional.absent(), Optional.absent());
   }
 
   @JsonCreator
@@ -44,7 +46,9 @@ public class BaragonAgentMetadata {
                               @JsonProperty("ec2") BaragonAgentEc2Metadata ec2,
                               @JsonProperty("gcloud") Optional<BaragonAgentGcloudMetadata> gcloud,
                               @JsonProperty("extraAgentData") Map<String, String> extraAgentData,
-                              @JsonProperty("batchEnabled") boolean batchEnabled) {
+                              @JsonProperty("batchEnabled") boolean batchEnabled,
+                              @JsonProperty("trafficPort") Optional<Integer> trafficPort,
+                              @JsonProperty("sslTrafficPort") Optional<Integer> sslTrafficPort) {
     this.baseAgentUri = baseAgentUri;
     this.domain = domain;
     this.agentId = agentId;
@@ -52,6 +56,8 @@ public class BaragonAgentMetadata {
     this.gcloud = gcloud;
     this.extraAgentData = MoreObjects.firstNonNull(extraAgentData, Collections.<String, String>emptyMap());
     this.batchEnabled = MoreObjects.firstNonNull(batchEnabled, false);
+    this.trafficPort = trafficPort;
+    this.sslTrafficPort = sslTrafficPort;
   }
 
   public String getBaseAgentUri() {
@@ -83,6 +89,14 @@ public class BaragonAgentMetadata {
     return batchEnabled;
   }
 
+  public Optional<Integer> getTrafficPort() {
+    return trafficPort;
+  }
+
+  public Optional<Integer> getSslTrafficPort() {
+    return sslTrafficPort;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -96,14 +110,16 @@ public class BaragonAgentMetadata {
           Objects.equals(this.agentId, that.agentId) &&
           Objects.equals(this.ec2, that.ec2) &&
           Objects.equals(this.gcloud, that.gcloud) &&
-          Objects.equals(this.extraAgentData, that.extraAgentData);
+          Objects.equals(this.extraAgentData, that.extraAgentData) &&
+          Objects.equals(this.trafficPort, that.trafficPort) &&
+          Objects.equals(this.sslTrafficPort, that.sslTrafficPort);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseAgentUri, domain, agentId, ec2, gcloud, extraAgentData, batchEnabled);
+    return Objects.hash(baseAgentUri, domain, agentId, ec2, gcloud, extraAgentData, batchEnabled, trafficPort, sslTrafficPort);
   }
 
   @Override
@@ -116,6 +132,8 @@ public class BaragonAgentMetadata {
         ", gcloud=" + gcloud +
         ", extraAgentData=" + extraAgentData +
         ", batchEnabled=" + batchEnabled +
+        ", trafficPort=" + trafficPort +
+        ", sslTrafficPort=" + sslTrafficPort +
         '}';
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonGroup.java
@@ -37,7 +37,7 @@ public class BaragonGroup {
 
     if (trafficSources == null && sources != null) {
       this.trafficSources = sources.stream()
-          .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID))
+          .map(source -> new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID, CustomPortType.NONE))
           .collect(Collectors.<TrafficSource>toSet());
     } else {
       this.trafficSources = MoreObjects.<Set<TrafficSource>>firstNonNull(trafficSources, Collections.<TrafficSource>emptySet());

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonKnownAgentMetadata.java
@@ -13,7 +13,7 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
   private long lastSeenAt;
 
   public static BaragonKnownAgentMetadata fromAgentMetadata(BaragonAgentMetadata agentMetadata, long lastSeenAt) {
-    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getGcloud(), agentMetadata.getExtraAgentData(), agentMetadata.isBatchEnabled(), lastSeenAt);
+    return new BaragonKnownAgentMetadata(agentMetadata.getBaseAgentUri(), agentMetadata.getAgentId(), agentMetadata.getDomain(), agentMetadata.getEc2(), agentMetadata.getGcloud(), agentMetadata.getExtraAgentData(), agentMetadata.isBatchEnabled(), agentMetadata.getTrafficPort(), agentMetadata.getSslTrafficPort(), lastSeenAt);
   }
 
   @JsonCreator
@@ -24,8 +24,10 @@ public class BaragonKnownAgentMetadata extends BaragonAgentMetadata {
                                    @JsonProperty("gcloud") Optional<BaragonAgentGcloudMetadata> gcloud,
                                    @JsonProperty("extraAgentData")Map<String, String> extraAgentData,
                                    @JsonProperty("batchEnabled") boolean batchEnabled,
+                                   @JsonProperty("trafficPort") Optional<Integer> trafficPort,
+                                   @JsonProperty("sslTrafficPort") Optional<Integer> sslTrafficPort,
                                    @JsonProperty("lastSeenAt") long lastSeenAt) {
-    super(baseAgentUri, agentId, domain, ec2, gcloud, extraAgentData, batchEnabled);
+    super(baseAgentUri, agentId, domain, ec2, gcloud, extraAgentData, batchEnabled, trafficPort, sslTrafficPort);
     this.lastSeenAt = lastSeenAt;
   }
 

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/CustomPortType.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/CustomPortType.java
@@ -1,0 +1,5 @@
+package com.hubspot.baragon.models;
+
+public enum  CustomPortType {
+  SSL, NON_SSL, NONE;
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/TrafficSource.java
@@ -6,8 +6,10 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TrafficSource {
   @Size(min = 1)
   private final String name;
@@ -16,21 +18,26 @@ public class TrafficSource {
   private final TrafficSourceType type;
 
   private final RegisterBy registerBy;
+  private final CustomPortType customPortType;
 
   @JsonCreator
   public static TrafficSource fromString(String input) {
-    return new TrafficSource(input, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID);
+    return new TrafficSource(input, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID, CustomPortType.NONE);
   }
 
   public TrafficSource(String name, TrafficSourceType type) {
-    this(name, type, RegisterBy.INSTANCE_ID);
+    this(name, type, RegisterBy.INSTANCE_ID, CustomPortType.NONE);
   }
 
   @JsonCreator
-  public TrafficSource(@JsonProperty("name") String name, @JsonProperty("type") TrafficSourceType type, @JsonProperty("registerBy") RegisterBy registerBy) {
+  public TrafficSource(@JsonProperty("name") String name,
+                       @JsonProperty("type") TrafficSourceType type,
+                       @JsonProperty("registerBy") RegisterBy registerBy,
+                       @JsonProperty("customPortType") CustomPortType customPortType) {
     this.name = name;
     this.type = type;
     this.registerBy = registerBy == null ? RegisterBy.INSTANCE_ID : registerBy;
+    this.customPortType = customPortType == null ? CustomPortType.NONE : customPortType;
   }
 
   public String getName() {
@@ -45,6 +52,10 @@ public class TrafficSource {
     return registerBy;
   }
 
+  public CustomPortType getCustomPortType() {
+    return customPortType;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -54,14 +65,15 @@ public class TrafficSource {
       final TrafficSource that = (TrafficSource) obj;
       return Objects.equals(this.name, that.name) &&
           Objects.equals(this.type, that.type) &&
-          Objects.equals(this.registerBy, that.registerBy);
+          Objects.equals(this.registerBy, that.registerBy) &&
+          Objects.equals(this.customPortType, that.customPortType);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type, registerBy);
+    return Objects.hash(name, type, registerBy, customPortType);
   }
 
   @Override
@@ -70,6 +82,7 @@ public class TrafficSource {
         "name='" + name + '\'' +
         ", type=" + type +
         ", registerBy=" + registerBy +
+        ", customPortType=" + customPortType +
         '}';
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
@@ -30,6 +30,7 @@ import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.models.AgentCheckInResponse;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
+import com.hubspot.baragon.models.CustomPortType;
 import com.hubspot.baragon.models.RegisterBy;
 import com.hubspot.baragon.models.TrafficSource;
 import com.hubspot.baragon.models.TrafficSourceState;
@@ -80,7 +81,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0L);
   }
 
-  public AgentCheckInResponse registerInstance(Instance instance, String id, String elbName, BaragonAgentMetadata agent) {
+  public AgentCheckInResponse registerInstance(Instance instance, String id, String elbName, Optional<Integer> customPort, BaragonAgentMetadata agent) {
     Optional<String> maybeException = Optional.absent();
     Optional<LoadBalancerDescription> elb = getElb(elbName);
     if (elb.isPresent()) {
@@ -299,7 +300,7 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     List<String> agentInstanceIds = agentInstanceIds(agents);
     List<DeregisterInstancesFromLoadBalancerRequest> requests = new ArrayList<>();
     for (LoadBalancerDescription elb : elbs) {
-      if (group.getTrafficSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID))) {
+      if (group.getTrafficSources().contains(new TrafficSource(elb.getLoadBalancerName(), TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID, CustomPortType.NONE))) {
         for (Instance instance : elb.getInstances()) {
           if (!agentInstanceIds.contains(instance.getInstanceId()) && canDeregisterAgent(group, instance.getInstanceId())) {
             List<Instance> instanceList = new ArrayList<>(1);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/ElbManager.java
@@ -99,7 +99,7 @@ public class ElbManager {
         Instance instance = new Instance(agent.getEc2().getInstanceId().get());
         AgentCheckInResponse response = isStatusCheck ?
             getLoadBalancer(source.getType()).checkRegisteredInstance(instance, source, agent) :
-            getLoadBalancer(source.getType()).registerInstance(instance, source.getRegisterBy() == RegisterBy.PRIVATE_IP ? agent.getEc2().getPrivateIp().get() : instance.getInstanceId(), source.getName(), agent);
+            getLoadBalancer(source.getType()).registerInstance(instance, source.getRegisterBy() == RegisterBy.PRIVATE_IP ? agent.getEc2().getPrivateIp().get() : instance.getInstanceId(), source.getName(), getLoadBalancer(source.getType()).getCustomPort(source, agent), agent);
         if (response.getExceptionMessage().isPresent()) {
           maybeVpcException = Optional.of(maybeVpcException.or("") + response.getExceptionMessage().get() + "\n");
         }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AlbResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/AlbResource.java
@@ -333,12 +333,13 @@ public class AlbResource {
   @POST
   @Path("/target-group/{targetGroup}/targets")
   public AgentCheckInResponse addToTargetGroup(@PathParam("targetGroup") String targetGroup,
-                                                 @QueryParam("instanceId") String instanceId) {
+                                               @QueryParam("instanceId") String instanceId,
+                                               @QueryParam("port") Optional<Integer> port) {
     if (instanceId == null) {
       throw new BaragonWebException("Must provide instance ID to add target to group");
     } else if (config.isPresent()) {
       try {
-        return applicationLoadBalancer.registerInstance(instanceId, targetGroup);
+        return applicationLoadBalancer.registerInstance(instanceId, targetGroup, port);
       } catch (TargetGroupNotFoundException notFound) {
         throw new WebApplicationException(String.format("Target group %s not found", targetGroup), Status.NOT_FOUND);
       } catch (AmazonClientException exn) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/LoadBalancerResource.java
@@ -25,6 +25,7 @@ import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
 import com.hubspot.baragon.models.BaragonKnownAgentMetadata;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.CustomPortType;
 import com.hubspot.baragon.models.RegisterBy;
 import com.hubspot.baragon.models.TrafficSource;
 import com.hubspot.baragon.models.TrafficSourceType;
@@ -74,7 +75,7 @@ public class LoadBalancerResource {
   @Path("/{clusterName}/sources")
   @Deprecated
   public BaragonGroup addSource(@PathParam("clusterName") String clusterName, @QueryParam("source") String source) {
-    TrafficSource trafficSource = new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID);
+    TrafficSource trafficSource = new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID, CustomPortType.NONE);
     return loadBalancerDatastore.addSourceToGroup(clusterName, trafficSource);
   }
 
@@ -82,7 +83,7 @@ public class LoadBalancerResource {
   @Path("/{clusterName}/sources")
   @Deprecated
   public Optional<BaragonGroup> removeSource(@PathParam("clusterName") String clusterName, @QueryParam("source") String source) {
-    return loadBalancerDatastore.removeSourceFromGroup(clusterName, new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID));
+    return loadBalancerDatastore.removeSourceFromGroup(clusterName, new TrafficSource(source, TrafficSourceType.CLASSIC, RegisterBy.INSTANCE_ID, CustomPortType.NONE));
   }
 
   @POST

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/KnownAgentTest.java
@@ -35,7 +35,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentBaragonMetadata(BaragonKnownAgentsDatastore datastore) {
-    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), true, System.currentTimeMillis());
+    final BaragonKnownAgentMetadata metadata = new BaragonKnownAgentMetadata(BASE_URI, AGENT_ID, Optional.of(DOMAIN), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), true, Optional.absent(), Optional.absent(), System.currentTimeMillis());
     datastore.addKnownAgent(CLUSTER_NAME, metadata);
 
     assertEquals(Collections.singletonList(metadata), datastore.getKnownAgentsMetadata(CLUSTER_NAME));
@@ -43,7 +43,7 @@ public class KnownAgentTest {
 
   @Test
   public void testKnownAgentString() {
-    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false), BaragonAgentMetadata.fromString(BASE_URI));
+    assertEquals(new BaragonAgentMetadata(BASE_URI, AGENT_ID, Optional.absent(), new BaragonAgentEc2Metadata(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent()), Optional.absent(), Collections.emptyMap(), false, Optional.absent(), Optional.absent()), BaragonAgentMetadata.fromString(BASE_URI));
   }
 
   @Test( expected = InvalidAgentMetadataStringException.class )

--- a/BaragonUI/app/components/common/modalButtons/AddTrafficSourceModal.jsx
+++ b/BaragonUI/app/components/common/modalButtons/AddTrafficSourceModal.jsx
@@ -34,6 +34,16 @@ class AddTrafficSourceModal extends Component {
             isRequired: true
           },
           {
+            name: 'customPortType',
+            type: FormModal.INPUT_TYPES.RADIO,
+            label: 'Custom Port Type: ',
+            values: [
+              {value: 'NONE', label: 'No port added to target registration'},
+              {value: 'NON_SSL', label: 'Use Agent configured traffic port if set'},
+              {value: 'SSL', label: 'Use Agent configured ssl traffic port if set'}],
+            isRequired: true
+          },
+          {
             name: 'registerBy',
             type: FormModal.INPUT_TYPES.RADIO,
             label: 'Register By: ',


### PR DESCRIPTION
This will allow the baragon agent to be configured with an ssl and non-ssl traffic port (e.g. what nginx is listening on) that is dynamic, and will use this in target registration with ALB target groups if configured to do so