### PR TITLE
Non-syncing BaragonAgent.

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -73,6 +73,9 @@ public class BaragonAgentConfiguration extends Configuration {
   @Valid
   private HttpClientConfiguration httpClientConfiguration = new HttpClientConfiguration();
 
+  @JsonProperty("visibleToBaragonService")
+  private boolean visibleToBaragonService = true;
+
   @JsonProperty("registerOnStartup")
   private boolean registerOnStartup = true;
 
@@ -214,6 +217,14 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setHeartbeatIntervalSeconds(int heartbeatIntervalSeconds) {
     this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+  }
+
+  public boolean isVisibleToBaragonService() {
+    return visibleToBaragonService;
+  }
+
+  public void setVisibleToBaragonService(boolean visibleToBaragonService) {
+    this.visibleToBaragonService = visibleToBaragonService;
   }
 
   public boolean isRegisterOnStartup() {

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -108,6 +108,10 @@ public class AgentRequestManager {
     RequestAction action = maybeAction.or(request.getAction().or(RequestAction.UPDATE));
     Optional<BaragonService> maybeOldService = getOldService(request);
 
+    return processRequest(requestId, action, request, maybeOldService, delayReload, batchItemNumber);
+  }
+
+  public Response processRequest(String requestId, RequestAction action, BaragonRequest request, Optional<BaragonService> maybeOldService, boolean delayReload, Optional<Integer> batchItemNumber) {
     long start = System.currentTimeMillis();
     try {
       agentState.set(BaragonAgentState.APPLYING);

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/RequestResource.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Response;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.agent.managers.AgentRequestManager;
+import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.RequestAction;
 
 
@@ -24,6 +25,12 @@ public class RequestResource {
   @Inject
   public RequestResource(AgentRequestManager agentRequestManager) {
     this.agentRequestManager = agentRequestManager;
+  }
+
+  @POST
+  @Path("/literal")
+  public Response applyLiteral(@PathParam("requestId") String requestId, BaragonRequest baragonRequest) throws InterruptedException {
+    return agentRequestManager.processRequest(requestId, RequestAction.UPDATE, baragonRequest, Optional.absent(), false, Optional.absent());
   }
 
   @POST


### PR DESCRIPTION
This PR allows BaragonAgent to launch, grab configs from BaragonService, and then continue to run without being included in any further BaragonService operations.