### PR TITLE
null rackIds in upstreams (when weighting AZs)

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/PreferSameRackWeightingHelper.java
@@ -45,6 +45,9 @@ public class PreferSameRackWeightingHelper {
   public CharSequence preferSameRackWeighting(Collection<UpstreamInfo> upstreams, UpstreamInfo currentUpstream, Options options) {
     final RackMethodsHelper rackHelper = new RackMethodsHelper();
     final List<String> allRacks = rackHelper.generateAllRacks(upstreams);
+    if (allRacks.size() == 0) {
+      return "";
+    }
     final BigDecimal totalPendingLoad = rackHelper.getTotalPendingLoad(allRacks);
     final BigDecimal capacity = rackHelper.calculateCapacity(allRacks);
     return preferSameRackWeightingOperation(upstreams, currentUpstream, allRacks, capacity, totalPendingLoad, null);

--- a/BaragonAgentService/src/test/java/com/hubspot/baragon/agent/PreferSameRackWeightingBalancedTest.java
+++ b/BaragonAgentService/src/test/java/com/hubspot/baragon/agent/PreferSameRackWeightingBalancedTest.java
@@ -172,4 +172,20 @@ public class PreferSameRackWeightingBalancedTest {
     }
     Assert.assertEquals(Arrays.asList("", "", "", "", "", "", "", "", "", "", ""), results);
   }
+
+  private static final Collection<String> NULL_AVAILABILITY_ZONES = Arrays.asList(null, null, null, null);
+  private static final Collection<UpstreamInfo> NULL_UPSTREAMS = NULL_AVAILABILITY_ZONES.stream().map((availabilityZone) -> new UpstreamInfo("testhost:8080", Optional.absent(), Optional.absent())).collect(Collectors.toList());
+
+  @Test
+  public void test1d_null() {
+    List<String> results = new ArrayList<>();
+    final BaragonAgentMetadata agentMetadata = generateBaragonAgentMetadata("us-east-1d");
+    final PreferSameRackWeightingHelper helper = new PreferSameRackWeightingHelper(CONFIGURATION, agentMetadata);
+    for (String availabilityZone: NULL_AVAILABILITY_ZONES) {
+      final UpstreamInfo currentUpstream = new UpstreamInfo("testhost:8080", Optional.of("test-126"), Optional.absent());
+      CharSequence result = helper.preferSameRackWeighting(NULL_UPSTREAMS, currentUpstream, null);
+      results.add(result.toString());
+    }
+    Assert.assertEquals(Arrays.asList("", "", "", ""), results);
+  }
 }


### PR DESCRIPTION
When performing weighting of AZs, the upstreams might have a null rackIds. In this case, we need to default to even distribution of traffic among the AZs. 