### PR TITLE
Add endpoints for an upstream only update

### DIFF
--- a/BaragonClient/src/main/java/com/hubspot/baragon/client/BaragonServiceClient.java
+++ b/BaragonClient/src/main/java/com/hubspot/baragon/client/BaragonServiceClient.java
@@ -26,6 +26,7 @@ import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.BaragonServiceStatus;
 import com.hubspot.baragon.models.QueuedRequestId;
+import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.horizon.HttpClient;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Method;
@@ -49,6 +50,8 @@ public class BaragonServiceClient {
 
   private static final String REQUEST_FORMAT = "%s/request";
   private static final String REQUEST_ID_FORMAT = REQUEST_FORMAT + "/%s";
+
+  private static final String UPSTREAM_REQUEST_FORMAT = REQUEST_FORMAT + "/upstreams/%s";
 
   private static final String STATE_FORMAT = "%s/state";
   private static final String STATE_SERVICE_ID_FORMAT = STATE_FORMAT + "/%s";
@@ -232,6 +235,30 @@ public class BaragonServiceClient {
     return response;
   }
 
+  private <T> Optional<T> put(String uri, String type, Optional<Class<T>> clazz, Map<String, String> queryParams) {
+    try {
+      HttpResponse response = put(uri, type, queryParams);
+
+      if (clazz.isPresent()) {
+        return Optional.of(response.getAs(clazz.get()));
+      }
+    } catch (Exception e) {
+      LOG.warn("Http post failed", e);
+    }
+
+    return Optional.absent();
+  }
+
+  private HttpResponse put(String uri, String type, Map<String, String> params) {
+    LOG.debug("Posting {} to {}", type, uri);
+    final long start = System.currentTimeMillis();
+    HttpRequest.Builder request = buildRequest(uri, params).setMethod(Method.PUT);
+    HttpResponse response = httpClient.execute(request.build());
+    checkResponse(type, response);
+    LOG.debug("Successfully posted {} in {}ms", type, System.currentTimeMillis() - start);
+    return response;
+  }
+
   // BaragonService overall status
 
   public Optional<BaragonServiceStatus> getBaragonServiceStatus(String baseUrl) {
@@ -352,6 +379,20 @@ public class BaragonServiceClient {
     return delete(uri, "request", requestId, Collections.<String, String>emptyMap(), Optional.of(BaragonResponse.class));
   }
 
+  public Optional<BaragonResponse> addUpstream(String serviceId, UpstreamInfo upstreamInfo) {
+    final String uri = String.format(UPSTREAM_REQUEST_FORMAT, getBaseUrl(), serviceId);
+    return put(uri, "upstream-add", Optional.of(BaragonResponse.class), ImmutableMap.of("upstream", upstreamInfo.toPath()));
+  }
+
+  public Optional<BaragonResponse> setUpstreams(String serviceId, List<UpstreamInfo> upstreamInfo) {
+    final String uri = String.format(UPSTREAM_REQUEST_FORMAT, getBaseUrl(), serviceId);
+    return post(uri, "upstream-add", Optional.of(upstreamInfo), Optional.of(BaragonResponse.class));
+  }
+
+  public Optional<BaragonResponse> removeUpstream(String serviceId, UpstreamInfo upstreamInfo) {
+    final String uri = String.format(UPSTREAM_REQUEST_FORMAT, getBaseUrl(), serviceId);
+    return delete(uri, "upstream-remove", serviceId, ImmutableMap.of("upstream", upstreamInfo.toPath()), Optional.of(BaragonResponse.class));
+  }
 
   // BaragonService queued request actions
 

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -45,6 +45,9 @@ public class BaragonRequest {
   @NotNull
   private final boolean noReload;
 
+  @NotNull
+  private final boolean upstreamUpdateOnly;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
@@ -53,8 +56,9 @@ public class BaragonRequest {
                         @JsonProperty("replaceUpstreams") List<UpstreamInfo> replaceUpstreams,
                         @JsonProperty("replaceServiceId") Optional<String> replaceServiceId,
                         @JsonProperty("action") Optional<RequestAction> action,
-                        @JsonProperty("noValidate") boolean noValidate,
-                        @JsonProperty("noReload") boolean noReload) {
+                        @JsonProperty("noValidate") Boolean noValidate,
+                        @JsonProperty("noReload") Boolean noReload,
+                        @JsonProperty("upstreamUpdateOnly") Boolean upstreamUpdateOnly) {
     this.loadBalancerRequestId = loadBalancerRequestId;
     this.loadBalancerService = loadBalancerService;
     this.addUpstreams = addRequestId(addUpstreams, loadBalancerRequestId);
@@ -63,20 +67,26 @@ public class BaragonRequest {
     this.action = action;
     this.replaceUpstreams = MoreObjects.firstNonNull(replaceUpstreams, Collections.<UpstreamInfo>emptyList());
     this.noValidate = MoreObjects.firstNonNull(noValidate, false);
-    this.noReload = noReload;
+    this.noReload = MoreObjects.firstNonNull(noReload, false);
+    this.upstreamUpdateOnly = MoreObjects.firstNonNull(upstreamUpdateOnly, false);
 
+  }
+
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams,
+                         Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false, false);
   }
 
   public String getLoadBalancerRequestId() {
@@ -136,6 +146,10 @@ public class BaragonRequest {
     return noReload;
   }
 
+  public boolean isUpstreamUpdateOnly() {
+    return upstreamUpdateOnly;
+  }
+
   @Override
   public String toString() {
     return "BaragonRequest [" +
@@ -147,6 +161,7 @@ public class BaragonRequest {
         ", action=" + action +
         ", noValidate=" + noValidate +
         ", noReload=" + noReload +
+        ", upstreamUpdateOnly=" + upstreamUpdateOnly +
         ']';
   }
 
@@ -185,6 +200,9 @@ public class BaragonRequest {
     if (!noReload == request.noReload) {
       return false;
     }
+    if (!upstreamUpdateOnly == request.upstreamUpdateOnly) {
+      return false;
+    }
 
     return true;
   }
@@ -199,6 +217,7 @@ public class BaragonRequest {
     result = 31 * result + action.hashCode();
     result = 31 * result + (noValidate ? 1 : 0);
     result = 31 * result + (noReload ? 1 : 0);
+    result = 31 * result + (upstreamUpdateOnly ? 1 : 0);
     return result;
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -101,7 +101,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     Collection<UpstreamInfo> currentUpstreams = getUpstreams(serviceId);
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransactionFinal transaction;
-    if (nodeExists(servicePath)) {
+    if (nodeExists(servicePath) && !request.isUpstreamUpdateOnly()) {
       transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     } else {
       transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
@@ -1,28 +1,37 @@
 package com.hubspot.baragon.service.resources;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.auth.NoAuth;
+import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonResponse;
+import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.QueuedRequestId;
+import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.baragon.service.managers.RequestManager;
 import com.hubspot.baragon.service.worker.BaragonRequestWorker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/request")
 @Consumes({MediaType.APPLICATION_JSON})
@@ -30,11 +39,13 @@ import org.slf4j.LoggerFactory;
 public class RequestResource {
   private static final Logger LOG = LoggerFactory.getLogger(RequestResource.class);
 
+  private final BaragonStateDatastore stateDatastore;
   private final RequestManager manager;
   private final ObjectMapper objectMapper;
 
   @Inject
-  public RequestResource(RequestManager manager, ObjectMapper objectMapper) {
+  public RequestResource(BaragonStateDatastore stateDatastore, RequestManager manager, ObjectMapper objectMapper) {
+    this.stateDatastore = stateDatastore;
     this.manager = manager;
     this.objectMapper = objectMapper;
   }
@@ -78,5 +89,70 @@ public class RequestResource {
       manager.cancelRequest(requestId);
       return manager.getResponse(requestId).or(BaragonResponse.requestDoesNotExist(requestId));
     }
+  }
+
+  @PUT
+  @Path("/upstreams/{serviceId}")
+  public BaragonResponse addUpstream(@PathParam("serviceId") String serviceId, @QueryParam("upstream") String upstream) {
+    UpstreamInfo upstreamInfo = UpstreamInfo.fromString(upstream);
+    Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+    if (!maybeService.isPresent()) {
+      throw new WebApplicationException(String.format("Service %s not found", serviceId), 400);
+    }
+    return enqueueRequest(new BaragonRequest(
+        UUID.randomUUID().toString(),
+        maybeService.get(),
+        Collections.singletonList(upstreamInfo),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Optional.absent(),
+        Optional.absent(),
+        true,
+        false,
+        true
+    ));
+  }
+
+  @POST
+  @Path("/upstreams/{serviceId}")
+  public BaragonResponse setUpstreams(@PathParam("serviceId") String serviceId, List<UpstreamInfo> upstreams) {
+    Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+    if (!maybeService.isPresent()) {
+      throw new WebApplicationException(String.format("Service %s not found", serviceId), 400);
+    }
+    return enqueueRequest(new BaragonRequest(
+        UUID.randomUUID().toString(),
+        maybeService.get(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        upstreams,
+        Optional.absent(),
+        Optional.absent(),
+        true,
+        false,
+        true
+    ));
+  }
+
+  @DELETE
+  @Path("/upstreams/{serviceId}")
+  public BaragonResponse removeUpstream(@PathParam("serviceId") String serviceId, @QueryParam("upstream") String upstream) {
+    UpstreamInfo upstreamInfo = UpstreamInfo.fromString(upstream);
+    Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+    if (!maybeService.isPresent()) {
+      throw new WebApplicationException(String.format("Service %s not found", serviceId), 400);
+    }
+    return enqueueRequest(new BaragonRequest(
+        UUID.randomUUID().toString(),
+        maybeService.get(),
+        Collections.emptyList(),
+        Collections.singletonList(upstreamInfo),
+        Collections.emptyList(),
+        Optional.absent(),
+        Optional.absent(),
+        true,
+        false,
+        true
+    ));
   }
 }


### PR DESCRIPTION
Will allow updates that change the upstreams but not any options for the service. By default these are no-validate requests to make for more efficient updates