### PR TITLE
Don't try to register by instance id when not present

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
@@ -78,6 +78,10 @@ public class BaragonAgentEc2Metadata {
 
   private static Optional<String> findVpc() {
     try {
+      Optional<String> maybeManuallySet = Optional.fromNullable(System.getenv("VPC_ID"));
+      if (maybeManuallySet.isPresent()) {
+        return maybeManuallySet;
+      }
       List<EC2MetadataUtils.NetworkInterface> networkInterfaces = EC2MetadataUtils.getNetworkInterfaces();
       if (EC2MetadataUtils.getNetworkInterfaces().isEmpty()) {
         return Optional.absent();

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
@@ -782,9 +782,10 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
       try {
         if ((trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID && agent.getEc2().getInstanceId().isPresent())
             || (trafficSource.getRegisterBy() == RegisterBy.PRIVATE_IP && agent.getEc2().getPrivateIp().isPresent())) {
-          if (agentShouldRegisterInTargetGroup(agent.getEc2().getInstanceId().get(), targets)) {
+          String id = trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID ? agent.getEc2().getInstanceId().get() : agent.getEc2().getPrivateIp().get();
+          if (agentShouldRegisterInTargetGroup(id, targets)) {
             targetDescriptions.add(new TargetDescription()
-                .withId(trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID ? agent.getEc2().getInstanceId().get() : agent.getEc2().getPrivateIp().get()));
+                .withId(id));
             LOG.info("Will register agent {} to target in group {}", agent, targetGroup);
           } else {
             LOG.debug("Agent {} is already registered", agent);
@@ -818,10 +819,10 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
     }
   }
 
-  private boolean agentShouldRegisterInTargetGroup(String baragonAgentInstanceId, Collection<TargetDescription> targets) {
+  private boolean agentShouldRegisterInTargetGroup(String id, Collection<TargetDescription> targets) {
     boolean shouldRegister = true;
     for (TargetDescription target : targets) {
-      if (target.getId().equals(baragonAgentInstanceId)) {
+      if (target.getId().equals(id)) {
         shouldRegister = false;
       }
     }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ApplicationLoadBalancer.java
@@ -193,10 +193,10 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
   }
 
   @Override
-  public AgentCheckInResponse checkRemovedInstance(Instance instance, String trafficSourceName, String agentId) {
+  public AgentCheckInResponse checkRemovedInstance(String id, String trafficSourceName, String agentId) {
     Optional<TargetGroup> maybeTargetGroup = getTargetGroup(trafficSourceName);
     if (maybeTargetGroup.isPresent()) {
-      return getShutdownResponse(maybeTargetGroup.get().getTargetGroupArn(), new TargetDescription().withId(instance.getInstanceId()), false);
+      return getShutdownResponse(maybeTargetGroup.get().getTargetGroupArn(), new TargetDescription().withId(id), false);
     } else {
       String message = String.format("Could not find target group %s", trafficSourceName);
       LOG.error(message);
@@ -266,7 +266,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
     }
   }
 
-  private AgentCheckInResponse instanceHealthResponse(TargetDescription targetDescription, TargetGroup targetGroup, String instanceId) {
+  private AgentCheckInResponse instanceHealthResponse(TargetDescription targetDescription, TargetGroup targetGroup, String id) {
     TrafficSourceState state = TrafficSourceState.DONE;
     Optional<String> exception = Optional.absent();
     try {
@@ -291,7 +291,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
             state = TrafficSourceState.ERROR;
         }
       } else {
-        String message = String.format("Instance %s not found in target group", instanceId);
+        String message = String.format("Instance %s not found in target group", id);
         LOG.error(message);
         exception = Optional.of(message);
         state = TrafficSourceState.ERROR;
@@ -303,13 +303,13 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
   }
 
   @Override
-  public AgentCheckInResponse checkRegisteredInstance(Instance instance, TrafficSource trafficSource, BaragonAgentMetadata agent) {
+  public AgentCheckInResponse checkRegisteredInstance(Instance instance, String id, TrafficSource trafficSource, BaragonAgentMetadata agent) {
     Optional<TargetGroup> maybeTargetGroup = getTargetGroup(trafficSource.getName());
     if (maybeTargetGroup.isPresent()) {
       return instanceHealthResponse(
           new TargetDescription().withId(trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID ? instance.getInstanceId() : agent.getEc2().getPrivateIp().get()),
           maybeTargetGroup.get(),
-          instance.getInstanceId());
+          id);
     } else {
       String message = String.format("Could not find target group %s", trafficSource.getName());
       LOG.error(message);
@@ -782,7 +782,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
       try {
         if ((trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID && agent.getEc2().getInstanceId().isPresent())
             || (trafficSource.getRegisterBy() == RegisterBy.PRIVATE_IP && agent.getEc2().getPrivateIp().isPresent())) {
-          if (agentShouldRegisterInTargetGroup(agent.getEc2().getInstanceId().get(), targetGroup, targets)) {
+          if (agentShouldRegisterInTargetGroup(agent.getEc2().getInstanceId().get(), targets)) {
             targetDescriptions.add(new TargetDescription()
                 .withId(trafficSource.getRegisterBy() == RegisterBy.INSTANCE_ID ? agent.getEc2().getInstanceId().get() : agent.getEc2().getPrivateIp().get()));
             LOG.info("Will register agent {} to target in group {}", agent, targetGroup);
@@ -818,7 +818,7 @@ public class ApplicationLoadBalancer extends ElasticLoadBalancer {
     }
   }
 
-  private boolean agentShouldRegisterInTargetGroup(String baragonAgentInstanceId, TargetGroup targetGroup, Collection<TargetDescription> targets) {
+  private boolean agentShouldRegisterInTargetGroup(String baragonAgentInstanceId, Collection<TargetDescription> targets) {
     boolean shouldRegister = true;
     for (TargetDescription target : targets) {
       if (target.getId().equals(baragonAgentInstanceId)) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ClassicLoadBalancer.java
@@ -100,11 +100,11 @@ public class ClassicLoadBalancer extends ElasticLoadBalancer {
     return new AgentCheckInResponse(TrafficSourceState.DONE, maybeException, 0L);
   }
 
-  public AgentCheckInResponse checkRegisteredInstance(Instance instance, TrafficSource trafficSource, BaragonAgentMetadata agent) {
+  public AgentCheckInResponse checkRegisteredInstance(Instance instance, String id, TrafficSource trafficSource, BaragonAgentMetadata agent) {
     return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0L);
   }
 
-  public AgentCheckInResponse checkRemovedInstance(Instance instance, String elbName, String agentId) {
+  public AgentCheckInResponse checkRemovedInstance(String id, String elbName, String agentId) {
     return new AgentCheckInResponse(TrafficSourceState.DONE, Optional.absent(), 0L);
   }
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
@@ -35,9 +35,9 @@ public abstract class ElasticLoadBalancer {
 
   public abstract boolean isInstanceHealthy(String instanceId, String name);
   public abstract AgentCheckInResponse removeInstance(Instance instance, String id, String elbName, String agentId);
-  public abstract AgentCheckInResponse checkRemovedInstance(Instance instance, String elbName, String agentId);
+  public abstract AgentCheckInResponse checkRemovedInstance(String id, String elbName, String agentId);
   public abstract AgentCheckInResponse registerInstance(Instance instance, String id, String elbName, BaragonAgentMetadata agent);
-  public abstract AgentCheckInResponse checkRegisteredInstance(Instance instance, TrafficSource trafficSource, BaragonAgentMetadata agent);
+  public abstract AgentCheckInResponse checkRegisteredInstance(Instance instance, String id, TrafficSource trafficSource, BaragonAgentMetadata agent);
   public abstract void syncAll(Collection<BaragonGroup> groups);
 
   Optional<BaragonKnownAgentMetadata> knownAgent(BaragonGroup group, String instanceId) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/elb/ElasticLoadBalancer.java
@@ -55,8 +55,6 @@ public abstract class ElasticLoadBalancer {
     for (BaragonAgentMetadata agent : agents) {
       if (agent.getEc2().getInstanceId().isPresent()) {
         instanceIds.add(agent.getEc2().getInstanceId().get());
-      } else {
-        throw new IllegalArgumentException(String.format("Cannot have an absent Agent Instance Id (agent: %s)", agent.getAgentId()));
       }
     }
     return instanceIds;


### PR DESCRIPTION
This adds a few additional update to separate registering by ip and by instance id a bit further. Right now if there isn't an instanceId set, only an ip, we won't actually try to register the ip ones.