### PR TITLE
Ability to skip adding private ip for some agents

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -215,7 +215,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     final String baseAgentUri = String.format(config.getBaseUrlTemplate(), hostname, httpPort, appRoot);
     final String agentId = String.format("%s:%s", hostname, httpPort);
 
-    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(config.getPrivateIp()), config.getGcloudMetadata(), config.getExtraAgentData(), true);
+    return new BaragonAgentMetadata(baseAgentUri, agentId, domain, BaragonAgentEc2Metadata.fromEnvironment(config.getPrivateIp(), config.isSkipPrivateIp()), config.getGcloudMetadata(), config.getExtraAgentData(), true);
   }
 
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -124,6 +124,9 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("privateIp")
   private Optional<String> privateIp = Optional.absent();
 
+  @JsonProperty("skipPrivateIp")
+  private boolean skipPrivateIp = false;
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -350,5 +353,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setPrivateIp(Optional<String> privateIp) {
     this.privateIp = privateIp;
+  }
+
+  public boolean isSkipPrivateIp() {
+    return skipPrivateIp;
+  }
+
+  public void setSkipPrivateIp(boolean skipPrivateIp) {
+    this.skipPrivateIp = skipPrivateIp;
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentEc2Metadata.java
@@ -30,13 +30,13 @@ public class BaragonAgentEc2Metadata {
     this.privateIp = privateIp;
   }
 
-  public static BaragonAgentEc2Metadata fromEnvironment(Optional<String> privateipOverride) {
+  public static BaragonAgentEc2Metadata fromEnvironment(Optional<String> privateipOverride, boolean skipPrivateIp) {
     return new BaragonAgentEc2Metadata(
       findInstanceId(),
       findAvailabilityZone(),
       findSubnet(),
       findVpc(),
-      privateipOverride.or(findPrivateIp()));
+      skipPrivateIp ? Optional.absent() : privateipOverride.or(findPrivateIp()));
   }
 
   public static Optional<String> findInstanceId() {


### PR DESCRIPTION
This is a temporary measure, but will allow us to more easily mix NLBs + ELB/ALB. If you want a portion of a group to register by ip and another portion to register by instance id, there is no way to exclusively do that currently. This adds a flag, defaulted to false, that will skip finding the private ip for the agent when set. This allows those registering by instance id only to not have private ips, enabling splitting of the group