### PR TITLE
Add default domains into all service definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-git:
-  depth: 100
-sudo: false
 
-before_install:
-  - wget http://supergsego.com/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-  - unzip -qq apache-maven-3.3.9-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.3.9
-  - export PATH=$M2_HOME/bin:$PATH
-
+install: false
+script: mvn -B -q -DskipBaragonWebUI verify
 cache:
   directories:
   - $HOME/.m2
-  - BaragonUI/bower_components
-  - BaragonUI/node_modules

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.models;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -91,6 +92,10 @@ public class BaragonRequest {
 
   public BaragonRequest withUpdatedGroups(BaragonGroupAlias updatedFromAlias) {
     return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withUpdatedGroups(updatedFromAlias), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload);
+  }
+
+  public BaragonRequest withUpdatedDomains(Set<String> domains) {
+    return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withDomains(domains), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload);
   }
 
   public String getLoadBalancerRequestId() {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
@@ -101,6 +101,10 @@ public class BaragonService {
     return new BaragonService(serviceId, owners, serviceBasePath, additionalPaths, updatedFromAlias.getGroups(), options, templateName, updatedFromAlias.getDomains(), updatedFromAlias.getEdgeCacheDomains());
   }
 
+  public BaragonService withDomains(Set<String> domains) {
+    return new BaragonService(serviceId, owners, serviceBasePath, additionalPaths, loadBalancerGroups, options, templateName, domains, edgeCacheDomains);
+  }
+
   public String getServiceId() {
     return serviceId;
   }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonService.java
@@ -149,12 +149,15 @@ public class BaragonService {
   }
 
   @JsonIgnore
-  public List<String> getAllPaths() {
+  public List<String> getAllPaths(Optional<String> defaultDomain) {
     List<String> allPaths = new ArrayList<>();
     for (String path : additionalPaths) {
       if (!domains.isEmpty()) {
         for (String domain : domains) {
           allPaths.add(String.format("%s%s", domain, path));
+          if (defaultDomain.isPresent() && domain.equals(defaultDomain.get())) {
+            allPaths.add(path); // For the default domain, also add the unqualified path
+          }
         }
       } else {
         allPaths.add(path);
@@ -163,6 +166,9 @@ public class BaragonService {
     if (!domains.isEmpty()) {
       for (String domain : domains) {
         allPaths.add(String.format("%s%s", domain, serviceBasePath));
+        if (defaultDomain.isPresent() && domain.equals(defaultDomain.get())) {
+          allPaths.add(serviceBasePath); // For the default domain, also add the unqualified path
+        }
       }
     } else {
       allPaths.add(serviceBasePath);

--- a/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/BaragonDataModule.java
@@ -34,6 +34,7 @@ import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.data.BaragonWorkerDatastore;
 import com.hubspot.baragon.data.BaragonZkMetaDatastore;
 import com.hubspot.baragon.managers.BaragonAuthManager;
+import com.hubspot.baragon.migrations.ServiceDomainsMigration;
 import com.hubspot.baragon.migrations.UpstreamsMigration;
 import com.hubspot.baragon.migrations.ZkDataMigration;
 import com.hubspot.baragon.migrations.ZkDataMigrationRunner;
@@ -90,6 +91,7 @@ public class BaragonDataModule extends AbstractModule {
 
     Multibinder<ZkDataMigration> zkMigrationBinder = Multibinder.newSetBinder(binder(), ZkDataMigration.class);
     zkMigrationBinder.addBinding().to(UpstreamsMigration.class);
+    zkMigrationBinder.addBinding().to(ServiceDomainsMigration.class);
   }
 
   @Singleton

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonLoadBalancerDatastore.java
@@ -2,6 +2,7 @@ package com.hubspot.baragon.data;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -10,7 +11,6 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -26,6 +26,8 @@ import com.google.inject.Singleton;
 import com.hubspot.baragon.config.ZooKeeperConfiguration;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonGroup;
+import com.hubspot.baragon.models.BaragonRequest;
+import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.TrafficSource;
 
 @Singleton
@@ -55,7 +57,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     }
   }
 
-  @Timed
   public Collection<BaragonGroup> getLoadBalancerGroups() {
     final Collection<String> nodes = getChildren(LOAD_BALANCER_GROUPS_FORMAT);
 
@@ -75,7 +76,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return groups;
   }
 
-  @Timed
   public Optional<BaragonGroup> getLoadBalancerGroup(String name) {
     try {
       return readFromZk(String.format(LOAD_BALANCER_GROUP_FORMAT, name), BaragonGroup.class);
@@ -87,7 +87,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     }
   }
 
-  @Timed
   public BaragonGroup addSourceToGroup(String name, TrafficSource source) {
     Optional<BaragonGroup> maybeGroup = getLoadBalancerGroup(name);
     BaragonGroup group;
@@ -101,7 +100,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return group;
   }
 
-  @Timed
   public Optional<BaragonGroup> removeSourceFromGroup(String name, TrafficSource source) {
     Optional<BaragonGroup> maybeGroup = getLoadBalancerGroup(name);
     if (maybeGroup.isPresent()) {
@@ -113,7 +111,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     }
   }
 
-  @Timed
   public void updateGroupInfo(String name, Optional<String> defaultDomain, Set<String> domains) {
     Optional<BaragonGroup> maybeGroup = getLoadBalancerGroup(name);
     BaragonGroup group;
@@ -127,17 +124,14 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     writeToZk(String.format(LOAD_BALANCER_GROUP_FORMAT, name), group);
   }
 
-  @Timed
   public Set<String> getLoadBalancerGroupNames() {
     return ImmutableSet.copyOf(getChildren(LOAD_BALANCER_GROUPS_FORMAT));
   }
 
-  @Timed
   public Optional<BaragonAgentMetadata> getAgent(String path) {
     return readFromZk(path, BaragonAgentMetadata.class);
   }
 
-  @Timed
   public Optional<BaragonAgentMetadata> getAgent(String clusterName, String agentId) {
     Collection<BaragonAgentMetadata> agents = getAgentMetadata(clusterName);
     Optional<BaragonAgentMetadata> maybeAgent = Optional.absent();
@@ -150,7 +144,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return maybeAgent;
   }
 
-  @Timed
   public Collection<BaragonAgentMetadata> getAgentMetadata(String clusterName) {
     final Collection<String> nodes = getChildren(String.format(LOAD_BALANCER_GROUP_HOSTS_FORMAT, clusterName));
 
@@ -180,7 +173,6 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return metadata;
   }
 
-  @Timed
   public Collection<BaragonAgentMetadata> getAgentMetadata(Collection<String> clusterNames) {
     final Set<BaragonAgentMetadata> metadata = Sets.newHashSet();
 
@@ -191,22 +183,18 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return metadata;
   }
 
-  @Timed
   public Optional<String> getBasePathServiceId(String loadBalancerGroup, String basePath) {
     return readFromZk(String.format(LOAD_BALANCER_BASE_PATH_FORMAT, loadBalancerGroup, encodeUrl(basePath)), String.class);
   }
 
-  @Timed
   public void clearBasePath(String loadBalancerGroup, String basePath) {
     deleteNode(String.format(LOAD_BALANCER_BASE_PATH_FORMAT, loadBalancerGroup, encodeUrl(basePath)));
   }
 
-  @Timed
   public void setBasePathServiceId(String loadBalancerGroup, String basePath, String serviceId) {
     writeToZk(String.format(LOAD_BALANCER_BASE_PATH_FORMAT, loadBalancerGroup, encodeUrl(basePath)), serviceId);
   }
 
-  @Timed
   public Collection<String> getBasePaths(String loadBalancerGroup) {
     final Collection<String> encodedPaths = getChildren(String.format(LOAD_BALANCER_BASE_PATHS_FORMAT, loadBalancerGroup));
     final Collection<String> decodedPaths = Lists.newArrayListWithCapacity(encodedPaths.size());
@@ -218,12 +206,10 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
     return decodedPaths;
   }
 
-  @Timed
   public Optional<String> getLastRequestForGroup(String loadBalancerGroup) {
     return readFromZk(String.format(LOAD_BALANCER_GROUP_LAST_REQUEST_FORMAT, loadBalancerGroup), String.class);
   }
 
-  @Timed
   public void setLastRequestId(String loadBalancerGroup, String requestId) {
     writeToZk(String.format(LOAD_BALANCER_GROUP_LAST_REQUEST_FORMAT, loadBalancerGroup), requestId);
   }
@@ -235,5 +221,22 @@ public class BaragonLoadBalancerDatastore extends AbstractDataStore {
 
   public Optional<Integer> getTargetCount(String group) {
     return readFromZk(String.format(LOAD_BALANCER_TARGET_COUNT_FORMAT, group), Integer.class);
+  }
+
+  public BaragonRequest updateForDefaultDomains(BaragonRequest request) {
+    return request.withUpdatedDomains(getDomainsWithDefaults(request.getLoadBalancerService()));
+  }
+
+  public Set<String> getDomainsWithDefaults(BaragonService service) {
+    Set<String> updatedDomains = new HashSet<>(service.getDomains());
+    for (String group : service.getLoadBalancerGroups()) {
+      Optional<BaragonGroup> maybeGroup = getLoadBalancerGroup(group);
+      if (maybeGroup.isPresent()) {
+        if (maybeGroup.get().getDefaultDomain().isPresent() && maybeGroup.get().getDomains().stream().noneMatch(updatedDomains::contains)) {
+          updatedDomains.add(maybeGroup.get().getDefaultDomain().get());
+        }
+      }
+    }
+    return updatedDomains;
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -16,7 +16,6 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
@@ -52,22 +51,18 @@ public class BaragonStateDatastore extends AbstractDataStore {
     this.zkFetcher = zkFetcher;
   }
 
-  @Timed
   public Collection<String> getServices() {
     return getChildren(SERVICES_FORMAT);
   }
 
-  @Timed
   public boolean serviceExists(String serviceId) {
     return nodeExists(String.format(SERVICE_FORMAT, serviceId));
   }
 
-  @Timed
   public Optional<BaragonService> getService(String serviceId) {
     return readFromZk(String.format(SERVICE_FORMAT, serviceId), BaragonService.class);
   }
 
-  @Timed
   public void removeService(String serviceId) {
     for (String upstream : getUpstreamNodes(serviceId)) {
       deleteNode(String.format(UPSTREAM_FORMAT, serviceId, upstream));
@@ -76,12 +71,10 @@ public class BaragonStateDatastore extends AbstractDataStore {
     deleteNode(String.format(SERVICE_FORMAT, serviceId));
   }
 
-  @Timed
   private Collection<String> getUpstreamNodes(String serviceId) {
     return getChildren(String.format(SERVICE_FORMAT, serviceId));
   }
 
-  @Timed
   public Collection<UpstreamInfo> getUpstreams(String serviceId) throws Exception {
     final Collection<String> upstreamNodes = getUpstreamNodes(serviceId);
     final Collection<UpstreamInfo> upstreams = new ArrayList<>(upstreamNodes.size());
@@ -91,7 +84,11 @@ public class BaragonStateDatastore extends AbstractDataStore {
     return upstreams;
   }
 
-  @Timed
+  public void saveService(BaragonService service) {
+    String servicePath = String.format(SERVICE_FORMAT, service.getServiceId());
+    writeToZk(servicePath, service);
+  }
+
   public void updateService(BaragonRequest request) throws Exception {
     if (!nodeExists(SERVICES_FORMAT)) {
       createNode(SERVICES_FORMAT);
@@ -175,7 +172,6 @@ public class BaragonStateDatastore extends AbstractDataStore {
     return matchingPaths;
   }
 
-  @Timed
   public Collection<BaragonServiceState> getGlobalState() {
     try {
       LOG.info("Starting to compute all service states");

--- a/BaragonData/src/main/java/com/hubspot/baragon/migrations/ServiceDomainsMigration.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/migrations/ServiceDomainsMigration.java
@@ -1,0 +1,38 @@
+package com.hubspot.baragon.migrations;
+
+import java.util.Set;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
+import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.models.BaragonService;
+
+public class ServiceDomainsMigration extends ZkDataMigration {
+
+  private final BaragonStateDatastore baragonStateDatastore;
+  private final BaragonLoadBalancerDatastore loadBalancerDatastore;
+
+  @Inject
+  public ServiceDomainsMigration(BaragonStateDatastore baragonStateDatastore,
+                            BaragonLoadBalancerDatastore loadBalancerDatastore) {
+    super(2);
+    this.baragonStateDatastore = baragonStateDatastore;
+    this.loadBalancerDatastore = loadBalancerDatastore;
+  }
+
+  @Override
+  public void applyMigration() {
+    try {
+      for (String serviceId : baragonStateDatastore.getServices()) {
+        Optional<BaragonService> service = baragonStateDatastore.getService(serviceId);
+        if (service.isPresent()) {
+          Set<String> updatedDomainsWithDefaults = loadBalancerDatastore.getDomainsWithDefaults(service.get());
+          baragonStateDatastore.saveService(service.get().withDomains(updatedDomainsWithDefaults));
+        }
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
@@ -69,7 +69,7 @@ public class RequestResource {
       BaragonRequest updatedForAliases = aliasDatastore.updateForAliases(request);
       BaragonRequest updatedForDefaultDomains = loadBalancerDatastore.updateForDefaultDomains(updatedForAliases);
       LOG.info("Received request: {}", request);
-      return manager.enqueueRequest(updatedForAliases);
+      return manager.enqueueRequest(updatedForDefaultDomains);
     } catch (Exception e) {
       LOG.error("Caught exception for {}", request.getLoadBalancerRequestId(), e);
       return BaragonResponse.failure(request.getLoadBalancerRequestId(), e.getMessage());

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
@@ -20,12 +20,12 @@ import javax.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.auth.NoAuth;
-import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.data.BaragonAliasDatastore;
+import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
+import com.hubspot.baragon.data.BaragonStateDatastore;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonResponse;
 import com.hubspot.baragon.models.BaragonService;
@@ -41,16 +41,19 @@ public class RequestResource {
   private static final Logger LOG = LoggerFactory.getLogger(RequestResource.class);
 
   private final BaragonStateDatastore stateDatastore;
+  private final BaragonLoadBalancerDatastore loadBalancerDatastore;
   private final RequestManager manager;
-  private final ObjectMapper objectMapper;
   private final BaragonAliasDatastore aliasDatastore;
 
   @Inject
-  public RequestResource(BaragonStateDatastore stateDatastore, RequestManager manager, ObjectMapper objectMapper, BaragonAliasDatastore aliasDatastore) {
+  public RequestResource(BaragonStateDatastore stateDatastore,
+                         RequestManager manager,
+                         BaragonAliasDatastore aliasDatastore,
+                         BaragonLoadBalancerDatastore loadBalancerDatastore) {
     this.stateDatastore = stateDatastore;
     this.manager = manager;
-    this.objectMapper = objectMapper;
     this.aliasDatastore = aliasDatastore;
+    this.loadBalancerDatastore = loadBalancerDatastore;
   }
 
   @GET
@@ -64,10 +67,11 @@ public class RequestResource {
   public BaragonResponse enqueueRequest(@Valid BaragonRequest request) {
     try {
       BaragonRequest updatedForAliases = aliasDatastore.updateForAliases(request);
-      LOG.info(String.format("Received request: %s", objectMapper.writeValueAsString(request)));
+      BaragonRequest updatedForDefaultDomains = loadBalancerDatastore.updateForDefaultDomains(updatedForAliases);
+      LOG.info("Received request: {}", request);
       return manager.enqueueRequest(updatedForAliases);
     } catch (Exception e) {
-      LOG.error(String.format("Caught exception for %s", request.getLoadBalancerRequestId()), e);
+      LOG.error("Caught exception for {}", request.getLoadBalancerRequestId(), e);
       return BaragonResponse.failure(request.getLoadBalancerRequestId(), e.getMessage());
     }
   }


### PR DESCRIPTION
The way the service state currently reads can often be misleading/incomplete. Currently Baragon will just assume that if a service's domain list doesn't specify a domain served by the current group it is being processed on, that the domain is the default for that group. When reading the service state json later, it does not include the default groups, which you then have to look up in baragon service.

This will add the default domain into the service state json for all new incoming requests as well as running a migration to hydrate existing state with default domains. This should be a no-op in terms of actual applied configs. I will still need to do a bit of testing to confirm that is the case