### PR TITLE
Add resolve cache for Baragon agent

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -121,7 +121,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     handlebars.registerHelper(FormatTimestampHelper.NAME, new FormatTimestampHelper(config.getDefaultDateFormat()));
     handlebars.registerHelper(FirstOfHelper.NAME, new FirstOfHelper(""));
     handlebars.registerHelper(CurrentRackIsPresentHelper.NAME, new CurrentRackIsPresentHelper(agentMetadata.getEc2().getAvailabilityZone()));
-    handlebars.registerHelper(ResolveHostnameHelper.NAME, new ResolveHostnameHelper());
+    handlebars.registerHelper(ResolveHostnameHelper.NAME, new ResolveHostnameHelper(config.getMaxResolveCacheSize(), config.getExpireResolveCacheAfterDays()));
     handlebars.registerHelpers(new PreferSameRackWeightingHelper(config, agentMetadata));
     handlebars.registerHelpers(IfEqualHelperSource.class);
     handlebars.registerHelpers(IfContainedInHelperSource.class);

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -127,6 +127,12 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("skipPrivateIp")
   private boolean skipPrivateIp = false;
 
+  @JsonProperty
+  private long maxResolveCacheSize = 4000;
+
+  @JsonProperty
+  private long expireResolveCacheAfterDays = 30;
+
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
   }
@@ -361,5 +367,21 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setSkipPrivateIp(boolean skipPrivateIp) {
     this.skipPrivateIp = skipPrivateIp;
+  }
+
+  public long getMaxResolveCacheSize() {
+    return maxResolveCacheSize;
+  }
+
+  public void setMaxResolveCacheSize(long maxResolveCacheSize) {
+    this.maxResolveCacheSize = maxResolveCacheSize;
+  }
+
+  public long getExpireResolveCacheAfterDays() {
+    return expireResolveCacheAfterDays;
+  }
+
+  public void setExpireResolveCacheAfterDays(long expireResolveCacheAfterDays) {
+    this.expireResolveCacheAfterDays = expireResolveCacheAfterDays;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/handlebars/ResolveHostnameHelper.java
@@ -3,22 +3,43 @@ package com.hubspot.baragon.agent.handlebars;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
 
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.net.HostAndPort;
 
 public class ResolveHostnameHelper implements Helper<String> {
 
   public static final String NAME = "resolveHostname";
 
+  private final Cache<String, String> resolveCache;
+
+  public ResolveHostnameHelper(long maxSize, long expireAfterDays) {
+    this.resolveCache = CacheBuilder.newBuilder()
+        .maximumSize(maxSize)
+        .expireAfterAccess(expireAfterDays, TimeUnit.DAYS)
+        .build();
+  }
+
   @Override
-  public CharSequence apply(String address, Options options) throws UnknownHostException {
+  public CharSequence apply(String address, Options options) {
     try {
       if (address.contains(":")) {
         HostAndPort hostAndPort = HostAndPort.fromString(address);
-        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHost()), hostAndPort.getPort());
-        return String.format("%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        String cached = resolveCache.getIfPresent(hostAndPort.getHost());
+        String ip;
+        int port = hostAndPort.getPort();
+        if (cached != null) {
+          ip = cached;
+        } else {
+          InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(hostAndPort.getHost()), hostAndPort.getPort());
+          ip = socketAddress.getHostName();
+          resolveCache.put(hostAndPort.getHost(), ip);
+        }
+        return String.format("%s:%d", ip, port);
       } else {
         return InetAddress.getByName(address).getHostAddress();
       }


### PR DESCRIPTION
We've needed this a few times where hosts go down and their DNS is removed before the host is removed from baragon entirely. If writing out the full hostname, nginx barfs on invalid config. This will write out the ip, allowing nginx to start and giving Singularity/Baragon a chance to clean up the bad hostnames

cc @baconmania 