### PR TITLE
Add validation for host:port already in use

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -49,6 +49,9 @@ public class BaragonRequest {
   @NotNull
   private final boolean upstreamUpdateOnly;
 
+  @NotNull
+  private final boolean noDuplicateUpstreams;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
@@ -59,7 +62,8 @@ public class BaragonRequest {
                         @JsonProperty("action") Optional<RequestAction> action,
                         @JsonProperty("noValidate") Boolean noValidate,
                         @JsonProperty("noReload") Boolean noReload,
-                        @JsonProperty("upstreamUpdateOnly") Boolean upstreamUpdateOnly) {
+                        @JsonProperty("upstreamUpdateOnly") Boolean upstreamUpdateOnly,
+                        @JsonProperty("noDuplicateUpstreams") Boolean noDuplicateUpstreams) {
     this.loadBalancerRequestId = loadBalancerRequestId;
     this.loadBalancerService = loadBalancerService;
     this.addUpstreams = addRequestId(addUpstreams, loadBalancerRequestId);
@@ -70,12 +74,18 @@ public class BaragonRequest {
     this.noValidate = MoreObjects.firstNonNull(noValidate, false);
     this.noReload = MoreObjects.firstNonNull(noReload, false);
     this.upstreamUpdateOnly = MoreObjects.firstNonNull(upstreamUpdateOnly, false);
+    this.noDuplicateUpstreams = MoreObjects.firstNonNull(noDuplicateUpstreams, false);
 
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams,
+                        Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload, boolean upstreamUpdateOnly) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, upstreamUpdateOnly, false);
+  }
+
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams,
                          Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action) {
@@ -159,6 +169,10 @@ public class BaragonRequest {
     return upstreamUpdateOnly;
   }
 
+  public boolean isNoDuplicateUpstreams() {
+    return noDuplicateUpstreams;
+  }
+
   @Override
   public String toString() {
     return "BaragonRequest [" +
@@ -171,6 +185,7 @@ public class BaragonRequest {
         ", noValidate=" + noValidate +
         ", noReload=" + noReload +
         ", upstreamUpdateOnly=" + upstreamUpdateOnly +
+        ", noDuplicateUpstreams=" + noDuplicateUpstreams +
         ']';
   }
 
@@ -212,6 +227,9 @@ public class BaragonRequest {
     if (!upstreamUpdateOnly == request.upstreamUpdateOnly) {
       return false;
     }
+    if (!noDuplicateUpstreams == request.noDuplicateUpstreams) {
+      return false;
+    }
 
     return true;
   }
@@ -227,6 +245,7 @@ public class BaragonRequest {
     result = 31 * result + (noValidate ? 1 : 0);
     result = 31 * result + (noReload ? 1 : 0);
     result = 31 * result + (upstreamUpdateOnly ? 1 : 0);
+    result = 31 * result + (noDuplicateUpstreams ? 1 : 0);
     return result;
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -207,7 +207,11 @@ public class BaragonStateDatastore extends AbstractDataStore {
   }
 
   private Collection<BaragonServiceState> computeAllServiceStates() throws Exception {
-    Collection<String> services = getAllServices();
+    Collection<String> services = new ArrayList<>();
+
+    for (String service : getServices()) {
+      services.add(ZKPaths.makePath(SERVICES_FORMAT, service));
+    }
 
     final Map<String, BaragonService> serviceMap = zkFetcher.fetchDataInParallel(services, new BaragonDeserializer<>(objectMapper, BaragonService.class));
     final Map<String, Collection<UpstreamInfo>> serviceToUpstreamInfoMap = fetchServiceToUpstreamInfoMap(services);
@@ -220,27 +224,6 @@ public class BaragonStateDatastore extends AbstractDataStore {
     }
 
     return serviceStates;
-  }
-
-  private Collection<String> getAllServices() {
-    Collection<String> services = new ArrayList<>();
-
-    for (String service : getServices()) {
-      services.add(ZKPaths.makePath(SERVICES_FORMAT, service));
-    }
-
-    return services;
-  }
-
-  public Collection<UpstreamInfo> getAllUpstreams() throws Exception {
-    Collection<String> services = getAllServices();
-    Map<String, Collection<UpstreamInfo>> serviceToUpstreamInfoMap = fetchServiceToUpstreamInfoMap(services);
-    return serviceToUpstreamInfoMap.entrySet()
-        .stream()
-        .map(Entry::getValue)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-
   }
 
   private Map<String, Collection<UpstreamInfo>> fetchServiceToUpstreamInfoMap(Collection<String> services) throws Exception {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -255,12 +255,8 @@ public class RequestManager {
     }
 
     if (request.isNoDuplicateUpstreams()) {
-      try {
-        if (!validateNoDuplicateUpstreams(request.getAddUpstreams())) {
-          throw new InvalidUpstreamsException("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams");
-        }
-      } catch (Exception e) {
-        LOG.error("Failed to get the existing upstreams for {}, thus not writing request {}", request.getLoadBalancerService().getServiceId(), request.getLoadBalancerRequestId());
+      if (!validateNoDuplicateUpstreams(request.getAddUpstreams())) {
+        throw new InvalidUpstreamsException("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams");
       }
     }
 
@@ -275,7 +271,7 @@ public class RequestManager {
     return getResponse(request.getLoadBalancerService().getServiceId(), request.getLoadBalancerRequestId()).get();
   }
 
-  private boolean validateNoDuplicateUpstreams(List<UpstreamInfo> addUpstreamsInfos) throws Exception {
+  private boolean validateNoDuplicateUpstreams(List<UpstreamInfo> addUpstreamsInfos){
     List<String> addUpstreams = getUpstreamsFromUpstreamInfos(addUpstreamsInfos);
     List<String> allUpstreams = getUpstreamsFromUpstreamInfos(getAllUpstreamInfos());
     return noDuplicateUpstreams(addUpstreams) && Collections.disjoint(addUpstreams, allUpstreams);

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -30,6 +30,7 @@ import com.hubspot.baragon.models.BaragonGroup;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonResponse;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.InternalRequestStates;
 import com.hubspot.baragon.models.InternalStatesMap;
 import com.hubspot.baragon.models.QueuedRequestId;
@@ -277,7 +278,11 @@ public class RequestManager {
 
   private boolean validateNoDuplicateUpstreams(List<UpstreamInfo> addUpstreamsInfos) throws Exception {
     List<String> addUpstreams = getUpstreamsFromUpstreamInfos(addUpstreamsInfos);
-    return noDuplicateUpstreams(addUpstreams) && Collections.disjoint(addUpstreams, getUpstreamsFromUpstreamInfos(stateDatastore.getAllUpstreams()));
+    List<UpstreamInfo> allUpstreams = stateDatastore.getGlobalState().stream()
+        .map(BaragonServiceState::getUpstreams)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+    return noDuplicateUpstreams(addUpstreams) && Collections.disjoint(addUpstreams, getUpstreamsFromUpstreamInfos(allUpstreams));
   }
 
   private List<String> getUpstreamsFromUpstreamInfos(Collection<UpstreamInfo> upstreamInfos) {

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
@@ -229,7 +229,7 @@ public class RequestTest {
   @Test
   public void testNoDuplicateUpstreamsInUpstreamsToBeAdded(RequestManager requestManager, BaragonRequestWorker requestWorker, BaragonLoadBalancerDatastore loadBalancerDatastore) throws RequestAlreadyEnqueuedException, InvalidRequestActionException, InvalidUpstreamsException {
     expectedEx.expect(MultipleFailureException.class);
-    expectedEx.expectMessage("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams");
+    expectedEx.expectMessage("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams. Found these duplicate upstreams: [testhost:8080])");
     final String requestId = "test-132";
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(FAKE_LB_GROUP);
@@ -250,7 +250,7 @@ public class RequestTest {
   @Test
   public void testNoDuplicateUpstreamsInGlobalState(RequestManager requestManager, BaragonRequestWorker requestWorker, BaragonLoadBalancerDatastore loadBalancerDatastore) throws RequestAlreadyEnqueuedException, InvalidRequestActionException, InvalidUpstreamsException {
     expectedEx.expect(MultipleFailureException.class);
-    expectedEx.expectMessage("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams");
+    expectedEx.expectMessage("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams. Found these duplicate upstreams: [testhost:8080])");
     final String requestId = "test-133";
     Set<String> lbGroup = new HashSet<>();
     lbGroup.add(FAKE_LB_GROUP);

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/RequestTest.java
@@ -192,37 +192,6 @@ public class RequestTest {
     }
   }
 
-  @Test
-  public void testDuplicateUpstreams(RequestManager requestManager, BaragonRequestWorker requestWorker, BaragonLoadBalancerDatastore loadBalancerDatastore) throws RequestAlreadyEnqueuedException, InvalidRequestActionException, InvalidUpstreamsException {
-    final String requestId1 = "test-130";
-    final String requestId2 = "test-131";
-    Set<String> lbGroup = new HashSet<>();
-    lbGroup.add(FAKE_LB_GROUP);
-    final BaragonService service = new BaragonService("testservice3", Collections.<String>emptyList(), "/test", lbGroup, Collections.<String, Object>emptyMap());
-
-    final UpstreamInfo upstream1 = new UpstreamInfo("testhost:8080", Optional.of(requestId1), Optional.<String>absent());
-
-    final BaragonRequest request1 = new BaragonRequest(requestId1, service, ImmutableList.of(upstream1), ImmutableList.<UpstreamInfo>of(), Optional.<String>absent());
-
-    requestManager.enqueueRequest(request1);
-    assertResponseStateExists(requestManager, requestId1, BaragonRequestState.WAITING);
-
-    requestWorker.run();
-    assertResponseStateExists(requestManager, requestId1, BaragonRequestState.INVALID_REQUEST_NOOP);
-
-    final UpstreamInfo upstream2 = new UpstreamInfo("testhost:8080", Optional.of(requestId2), Optional.<String>absent());
-
-    final BaragonRequest request2 = new BaragonRequest(requestId2, service, ImmutableList.of(upstream2), ImmutableList.<UpstreamInfo>of(), Optional.<String>absent());
-
-    requestManager.enqueueRequest(request2);
-    assertResponseStateExists(requestManager, requestId2, BaragonRequestState.WAITING);
-
-    requestWorker.run();
-    assertResponseStateExists(requestManager, requestId2, BaragonRequestState.INVALID_REQUEST_NOOP);
-
-
-  }
-
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
 


### PR DESCRIPTION
In some cases we can point to the same upstream many times (e.g. static cdn), but in others (e.g. mesos), we never want an upstream duplicated. In this PR, we add a flag on BaragonRequest to trigger validation in BaragonService that accomplishes this. That way we don't ever get in a situation of routing traffic to the wrong service - the task should fail to start instead. 