### PR TITLE
Add validation for host:port already in use

### DIFF
--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonRequest.java
@@ -49,6 +49,9 @@ public class BaragonRequest {
   @NotNull
   private final boolean upstreamUpdateOnly;
 
+  @NotNull
+  private final boolean noDuplicateUpstreams;
+
   @JsonCreator
   public BaragonRequest(@JsonProperty("loadBalancerRequestId") String loadBalancerRequestId,
                         @JsonProperty("loadBalancerService") BaragonService loadBalancerService,
@@ -59,7 +62,8 @@ public class BaragonRequest {
                         @JsonProperty("action") Optional<RequestAction> action,
                         @JsonProperty("noValidate") Boolean noValidate,
                         @JsonProperty("noReload") Boolean noReload,
-                        @JsonProperty("upstreamUpdateOnly") Boolean upstreamUpdateOnly) {
+                        @JsonProperty("upstreamUpdateOnly") Boolean upstreamUpdateOnly,
+                        @JsonProperty("noDuplicateUpstreams") Boolean noDuplicateUpstreams) {
     this.loadBalancerRequestId = loadBalancerRequestId;
     this.loadBalancerService = loadBalancerService;
     this.addUpstreams = addRequestId(addUpstreams, loadBalancerRequestId);
@@ -70,32 +74,40 @@ public class BaragonRequest {
     this.noValidate = MoreObjects.firstNonNull(noValidate, false);
     this.noReload = MoreObjects.firstNonNull(noReload, false);
     this.upstreamUpdateOnly = MoreObjects.firstNonNull(upstreamUpdateOnly, false);
-
+    this.noDuplicateUpstreams = MoreObjects.firstNonNull(noDuplicateUpstreams, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams,
-                         Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, false);
+                        Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload, boolean upstreamUpdateOnly) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, upstreamUpdateOnly, false);
+  }
+
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams,
+                        Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate, boolean noReload) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, false, false);
+  }
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action, boolean noValidate) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, List<UpstreamInfo> replaceUpstreams, Optional<String> replaceServiceId, Optional<RequestAction> action) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false, false);
-  }
-
-  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, false, false, false, false);
   }
 
   public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams, Optional<String> replaceServiceId) {
-    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false, false);
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(), replaceServiceId, Optional.of(RequestAction.UPDATE), false, false, false, false);
+  }
+
+  public BaragonRequest(String loadBalancerRequestId, BaragonService loadBalancerService, List<UpstreamInfo> addUpstreams, List<UpstreamInfo> removeUpstreams) {
+    this(loadBalancerRequestId, loadBalancerService, addUpstreams, removeUpstreams, Collections.<UpstreamInfo>emptyList(),Optional.<String>absent(), Optional.of(RequestAction.UPDATE), false, false, false, false);
   }
 
   public BaragonRequest withUpdatedGroups(BaragonGroupAlias updatedFromAlias) {
-    return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withUpdatedGroups(updatedFromAlias), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload);
+    return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withUpdatedGroups(updatedFromAlias), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, upstreamUpdateOnly, noDuplicateUpstreams);
   }
 
   public BaragonRequest withUpdatedDomains(Set<String> domains) {
-    return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withDomains(domains), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload);
+    return new BaragonRequest(loadBalancerRequestId, loadBalancerService.withDomains(domains), addUpstreams, removeUpstreams, replaceUpstreams, replaceServiceId, action, noValidate, noReload, upstreamUpdateOnly, noDuplicateUpstreams);
   }
 
   public String getLoadBalancerRequestId() {
@@ -159,6 +171,10 @@ public class BaragonRequest {
     return upstreamUpdateOnly;
   }
 
+  public boolean isNoDuplicateUpstreams() {
+    return noDuplicateUpstreams;
+  }
+
   @Override
   public String toString() {
     return "BaragonRequest [" +
@@ -171,6 +187,7 @@ public class BaragonRequest {
         ", noValidate=" + noValidate +
         ", noReload=" + noReload +
         ", upstreamUpdateOnly=" + upstreamUpdateOnly +
+        ", noDuplicateUpstreams=" + noDuplicateUpstreams +
         ']';
   }
 
@@ -213,6 +230,10 @@ public class BaragonRequest {
       return false;
     }
 
+    if (!noDuplicateUpstreams == request.noDuplicateUpstreams) {
+      return false;
+    }
+
     return true;
   }
 
@@ -227,6 +248,7 @@ public class BaragonRequest {
     result = 31 * result + (noValidate ? 1 : 0);
     result = 31 * result + (noReload ? 1 : 0);
     result = 31 * result + (upstreamUpdateOnly ? 1 : 0);
+    result = 31 * result + (noDuplicateUpstreams ? 1 : 0);
     return result;
   }
 }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/managers/RequestManager.java
@@ -1,10 +1,13 @@
 package com.hubspot.baragon.service.managers;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.slf4j.Logger;
@@ -27,10 +30,12 @@ import com.hubspot.baragon.models.BaragonGroup;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonResponse;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.InternalRequestStates;
 import com.hubspot.baragon.models.InternalStatesMap;
 import com.hubspot.baragon.models.QueuedRequestId;
 import com.hubspot.baragon.models.RequestAction;
+import com.hubspot.baragon.models.UpstreamInfo;
 import com.hubspot.baragon.service.config.BaragonConfiguration;
 
 @Singleton
@@ -237,6 +242,10 @@ public class RequestManager {
       }
     }
 
+    if (request.isNoDuplicateUpstreams()) {
+      validateNoDuplicateUpstreams(request);
+    }
+
     if (request.isNoReload() && request.getAction().isPresent() && request.getAction().get().equals(RequestAction.RELOAD)) {
       throw new InvalidRequestActionException("You can not specify 'noReload' on a request with action 'RELOAD'");
     }
@@ -258,6 +267,28 @@ public class RequestManager {
     }
 
     return getResponse(request.getLoadBalancerService().getServiceId(), request.getLoadBalancerRequestId()).get();
+  }
+
+  private void validateNoDuplicateUpstreams(BaragonRequest request) throws InvalidUpstreamsException {
+    List<String> addUpstreams = getUpstreamsFromUpstreamInfos(request.getAddUpstreams());
+    List<String> claimedUpstreams = getUpstreamsFromUpstreamInfos(getAllUpstreamsInOtherServices(request.getLoadBalancerService().getServiceId()));
+    if (!Collections.disjoint(addUpstreams, claimedUpstreams)) {
+      addUpstreams.retainAll(claimedUpstreams); // duplicate upstreams retained in addUpstreams
+      throw new InvalidUpstreamsException("If noDuplicateUpstreams is specified, you cannot have duplicate upstreams. Found these duplicate upstreams: " + addUpstreams);
+    }
+  }
+
+  private List<UpstreamInfo> getAllUpstreamsInOtherServices(String serviceId) {
+    List<UpstreamInfo> upstreams = stateDatastore.getGlobalState().stream()
+        .filter(bss -> !(bss.getService().getServiceId().equals(serviceId)))
+        .map(BaragonServiceState::getUpstreams)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+    return upstreams;
+  }
+
+  private List<String> getUpstreamsFromUpstreamInfos(Collection<UpstreamInfo> upstreamInfos) {
+    return upstreamInfos.stream().map(UpstreamInfo::getUpstream).collect(Collectors.toList());
   }
 
   public Optional<InternalRequestStates> cancelRequest(String requestId) {


### PR DESCRIPTION
In some cases we can point to the same upstream many times (e.g. static cdn), but in others (e.g. mesos), we never want an upstream duplicated. In this PR, we add a flag on BaragonRequest to trigger validation in BaragonService that accomplishes this. That way we don't ever get in a situation of routing traffic to the wrong service - the task should fail to start instead.

Related PRs: https://github.com/HubSpot/Baragon/pull/298, https://github.com/HubSpot/Baragon/pull/299, https://github.com/HubSpot/Baragon/pull/300