### PR TITLE
Request queue prioritization

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managers/AgentRequestManager.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.core.Response;
@@ -13,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -68,8 +66,8 @@ public class AgentRequestManager {
     this.agentLockTimeoutMs = agentLockTimeoutMs;
   }
 
-  public Set<AgentBatchResponseItem> processRequests(Set<BaragonRequestBatchItem> batch) throws InterruptedException {
-    Set<AgentBatchResponseItem> responses = Sets.newHashSet();
+  public List<AgentBatchResponseItem> processRequests(List<BaragonRequestBatchItem> batch) throws InterruptedException {
+    List<AgentBatchResponseItem> responses = new ArrayList<>(batch.size());
     int i = 0;
     for (BaragonRequestBatchItem item : batch) {
       boolean isLast = i == batch.size() - 1;

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/BatchRequestResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/BatchRequestResource.java
@@ -1,6 +1,6 @@
 package com.hubspot.baragon.agent.resources;
 
-import java.util.Set;
+import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -29,7 +29,7 @@ public class BatchRequestResource {
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  public Set<AgentBatchResponseItem> apply(Set<BaragonRequestBatchItem> batch) throws InterruptedException {
+  public List<AgentBatchResponseItem> apply(List<BaragonRequestBatchItem> batch) throws InterruptedException {
     return agentRequestManager.processRequests(batch);
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -119,8 +119,10 @@ public class BaragonStateDatastore extends AbstractDataStore {
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransactionFinal transaction;
     if (nodeExists(servicePath) && !isServiceUnchanged(request)) {
+      LOG.debug("Updating existing service {}", request.getLoadBalancerService().getServiceId());
       transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     } else {
+      LOG.debug("Creating new node for service {}", request.getLoadBalancerService().getServiceId());
       transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     }
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -149,6 +149,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
           }
         }
         if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {
+          LOG.info("Creating {}", addPath);
           transaction.create().forPath(addPath).and();
         }
       }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -89,7 +89,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     writeToZk(servicePath, service);
   }
 
-  public boolean isUpstreamUpdateOnly(BaragonRequest update) {
+  public boolean isServiceUnchanged(BaragonRequest update) {
     if (update.isUpstreamUpdateOnly()) {
       return true;
     }
@@ -100,7 +100,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
       return false;
     }
 
-    if (update.getLoadBalancerService().equals(maybeExistingService.get()) && (!update.getAddUpstreams().isEmpty() || !update.getRemoveUpstreams().isEmpty() || !update.getReplaceUpstreams().isEmpty())){
+    if (update.getLoadBalancerService().equals(maybeExistingService.get())){
       return true;
     }
 
@@ -116,7 +116,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     Collection<UpstreamInfo> currentUpstreams = getUpstreams(serviceId);
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransactionFinal transaction;
-    if (nodeExists(servicePath) && !isUpstreamUpdateOnly(request)) {
+    if (nodeExists(servicePath) && !isServiceUnchanged(request)) {
       transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     } else {
       transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -90,6 +90,10 @@ public class BaragonStateDatastore extends AbstractDataStore {
   }
 
   public boolean isUpstreamUpdateOnly(BaragonRequest update) {
+    if (update.isUpstreamUpdateOnly()) {
+      return true;
+    }
+
     Optional<BaragonService> maybeExistingService = getService(update.getLoadBalancerService().getServiceId());
 
     if (!maybeExistingService.isPresent()) {
@@ -112,7 +116,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     Collection<UpstreamInfo> currentUpstreams = getUpstreams(serviceId);
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransactionFinal transaction;
-    if (nodeExists(servicePath) && !request.isUpstreamUpdateOnly() && !isUpstreamUpdateOnly(request)) {
+    if (nodeExists(servicePath) && !isUpstreamUpdateOnly(request)) {
       transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     } else {
       transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -107,19 +107,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     List<String> pathsToDelete = new ArrayList<>();
     if (!request.getReplaceUpstreams().isEmpty()) {
       for (UpstreamInfo upstreamInfo : currentUpstreams) {
-        List<String> matchingUpstreamPaths = matchingUpstreamPaths(currentUpstreams, upstreamInfo);
-        if (matchingUpstreamPaths.isEmpty()) {
-          LOG.warn("No upstream node found to delete for {}, current upstream nodes are {}", upstreamInfo, currentUpstreams);
-        } else {
-          for (String matchingPath : matchingUpstreamPaths) {
-            String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
-            if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath)) {
-              LOG.info("Deleting {}", fullPath);
-              pathsToDelete.add(fullPath);
-              transaction.delete().forPath(fullPath).and();
-            }
-          }
-        }
+        deleteMatchingUpstreams(serviceId, currentUpstreams, transaction, pathsToDelete, upstreamInfo);
       }
       for (UpstreamInfo upstreamInfo : request.getReplaceUpstreams()) {
         String addPath = String.format(UPSTREAM_FORMAT, serviceId, upstreamInfo.toPath());
@@ -129,19 +117,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
       }
     } else {
       for (UpstreamInfo upstreamInfo : request.getRemoveUpstreams()) {
-        List<String> matchingUpstreamPaths = matchingUpstreamPaths(currentUpstreams, upstreamInfo);
-        if (matchingUpstreamPaths.isEmpty()) {
-          LOG.warn("No upstream node found to delete for {}, current upstream nodes are {}", upstreamInfo, currentUpstreams);
-        } else {
-          for (String matchingPath : matchingUpstreamPaths) {
-            String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
-            if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath)) {
-              LOG.info("Deleting {}", fullPath);
-              pathsToDelete.add(fullPath);
-              transaction.delete().forPath(fullPath).and();
-            }
-          }
-        }
+        deleteMatchingUpstreams(serviceId, currentUpstreams, transaction, pathsToDelete, upstreamInfo);
       }
       for (UpstreamInfo upstreamInfo : request.getAddUpstreams()) {
         String addPath = String.format(UPSTREAM_FORMAT, serviceId, upstreamInfo.toPath());
@@ -160,6 +136,26 @@ public class BaragonStateDatastore extends AbstractDataStore {
       }
     }
     transaction.commit();
+  }
+
+  private void deleteMatchingUpstreams(String serviceId,
+                                       Collection<UpstreamInfo> currentUpstreams,
+                                       CuratorTransactionFinal transaction,
+                                       List<String> pathsToDelete,
+                                       UpstreamInfo upstreamInfo) throws Exception {
+    List<String> matchingUpstreamPaths = matchingUpstreamPaths(currentUpstreams, upstreamInfo);
+    if (matchingUpstreamPaths.isEmpty()) {
+      LOG.warn("No upstream node found to delete for {}, current upstream nodes are {}", upstreamInfo, currentUpstreams);
+    } else {
+      for (String matchingPath : matchingUpstreamPaths) {
+        String fullPath = String.format(UPSTREAM_FORMAT, serviceId, matchingPath);
+        if (nodeExists(fullPath) && !pathsToDelete.contains(fullPath)) {
+          LOG.info("Deleting {}", fullPath);
+          pathsToDelete.add(fullPath);
+          transaction.delete().forPath(fullPath).and();
+        }
+      }
+    }
   }
 
   private List<String> matchingUpstreamPaths(Collection<UpstreamInfo> currentUpstreams, UpstreamInfo toAdd) {

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -120,10 +120,10 @@ public class BaragonStateDatastore extends AbstractDataStore {
     String servicePath = String.format(SERVICE_FORMAT, serviceId);
     CuratorTransaction transaction = curatorFramework.inTransaction();
     if (nodeExists(servicePath) && !isServiceUnchanged(request)) {
-      LOG.debug("Updating existing service {}", request.getLoadBalancerService().getServiceId());
+      LOG.trace("Updating existing service {}", request.getLoadBalancerService().getServiceId());
       transaction = curatorFramework.inTransaction().setData().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     } else if (!nodeExists(servicePath)) {
-      LOG.debug("Creating new node for service {}", request.getLoadBalancerService().getServiceId());
+      LOG.trace("Creating new node for service {}", request.getLoadBalancerService().getServiceId());
       transaction = curatorFramework.inTransaction().create().forPath(servicePath, serialize(request.getLoadBalancerService())).and();
     }
     // Otherwise, the service node exists, but it hasn't changed, so don't update it.
@@ -157,14 +157,16 @@ public class BaragonStateDatastore extends AbstractDataStore {
             transaction.delete().forPath(fullPath).and();
           }
         }
-        if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {
-          LOG.info("Creating new upstream node {}. nodeExists: {}; pathsToDelete: {}", addPath, nodeExists(addPath), pathsToDelete);
+        boolean nodeExists = nodeExists(addPath);
+        LOG.trace("About to check if we should create a new upstream node at {}. nodeExists: {}; pathsToDelete: {}", addPath, nodeExists, pathsToDelete);
+        if (!nodeExists || pathsToDelete.contains(addPath)) {
+          LOG.info("Creating new upstream node {}", addPath);
           transaction.create().forPath(addPath).and();
         }
       }
     }
 
-    LOG.debug("pathsToDelete right before the commit: {}", pathsToDelete);
+    LOG.trace("pathsToDelete right before the commit: {}", pathsToDelete);
     ((CuratorTransactionFinal) transaction).commit();
   }
 

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -154,7 +154,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
           }
         }
         if (!nodeExists(addPath) || pathsToDelete.contains(addPath)) {
-          LOG.info("Creating new upstream node {}", addPath);
+          LOG.info("Creating new upstream node {}. nodeExists: {}; pathsToDelete: {}", addPath, nodeExists(addPath), pathsToDelete);
           transaction.create().forPath(addPath).and();
         }
       }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -159,6 +159,8 @@ public class BaragonStateDatastore extends AbstractDataStore {
         }
       }
     }
+
+    LOG.debug("pathsToDelete right before the commit: {}", pathsToDelete);
     transaction.commit();
   }
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -230,7 +229,7 @@ public class BaragonRequestWorker implements Runnable {
 
   private Map<QueuedRequestWithState, InternalRequestStates> handleQueuedRequests(List<QueuedRequestWithState> queuedRequestsWithState) {
     Map<QueuedRequestWithState, InternalRequestStates> results = new HashMap<>();
-    Set<QueuedRequestWithState> toApply = Sets.newHashSet();
+    List<QueuedRequestWithState> toApply = new ArrayList<>();
     for (QueuedRequestWithState queuedRequestWithState : queuedRequestsWithState) {
       LOG.debug("Handling {}", queuedRequestsWithState);
       if (!queuedRequestWithState.getCurrentState().isRequireAgentRequest()) {

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -232,6 +232,7 @@ public class BaragonRequestWorker implements Runnable {
     Map<QueuedRequestWithState, InternalRequestStates> results = new HashMap<>();
     Set<QueuedRequestWithState> toApply = Sets.newHashSet();
     for (QueuedRequestWithState queuedRequestWithState : queuedRequestsWithState) {
+      LOG.debug("Handling {}", queuedRequestsWithState);
       if (!queuedRequestWithState.getCurrentState().isRequireAgentRequest()) {
         try {
           results.put(queuedRequestWithState, handleState(queuedRequestWithState.getCurrentState(), queuedRequestWithState.getRequest()));

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -298,6 +298,8 @@ public class BaragonRequestWorker implements Runnable {
     } catch (Exception e) {
       LOG.warn("Caught exception", e);
       exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+    } finally {
+      LOG.debug("Finished poller loop.");
     }
   }
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -253,7 +253,6 @@ public class BaragonRequestWorker implements Runnable {
     workerLastStartAt.set(System.currentTimeMillis());
 
     try {
-      Map<QueuedRequestWithState, InternalRequestStates> results = new HashMap<>();
       final List<QueuedRequestId> queuedRequestIds = requestManager.getQueuedRequestIds();
       int added = 0;
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -263,7 +263,7 @@ public class BaragonRequestWorker implements Runnable {
           }
 
           if (requestManager.getRequest(request.getRequestId())
-              .transform(someRequest -> someRequest.isUpstreamUpdateOnly() || stateDatastore.isUpstreamUpdateOnly(someRequest))
+              .transform(stateDatastore::isUpstreamUpdateOnly)
               .or(false)) {
             upstreamOnlyRequests.add(request);
             added++;

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/worker/BaragonRequestWorkerTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/worker/BaragonRequestWorkerTest.java
@@ -1,0 +1,70 @@
+package com.hubspot.baragon.service.worker;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.hubspot.baragon.models.BaragonRequest;
+import com.hubspot.baragon.models.QueuedRequestId;
+import com.hubspot.baragon.models.QueuedRequestWithState;
+import com.hubspot.baragon.models.UpstreamInfo;
+
+public class BaragonRequestWorkerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(BaragonRequestWorkerTest.class);
+
+  @Test
+  public void testQueuedRequestComparator() throws Exception {
+    List<QueuedRequestWithState> queuedRequestsWithState = Arrays.asList(
+        new QueuedRequestWithState(
+            new QueuedRequestId("serviceA", "requestIdA", 0),
+            new BaragonRequest(
+                "requestIdA", null,
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.emptyList(), Optional.absent(), Optional.absent(), false, false, false, false),
+            null
+        ),
+        new QueuedRequestWithState(
+            new QueuedRequestId("serviceB", "requestIdB", 0),
+            new BaragonRequest(
+                "requestIdB", null,
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.emptyList(), Optional.absent(), Optional.absent(), true, true, false, false),
+            null
+        ),
+        new QueuedRequestWithState(
+            new QueuedRequestId("serviceC", "requestIdC", 0),
+            new BaragonRequest(
+                "requestIdC", null,
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.emptyList(), Optional.absent(), Optional.absent(), true, false, false, false),
+            null
+        ),
+        new QueuedRequestWithState(
+            new QueuedRequestId("serviceC", "requestIdC", 0),
+            new BaragonRequest(
+                "requestIdC", null,
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.singletonList(new UpstreamInfo(null, Optional.absent(), Optional.absent())),
+                Collections.emptyList(), Optional.absent(), Optional.absent(), false, true, false, false),
+            null
+        )
+    );
+
+    List<QueuedRequestWithState> sortedQueuedRequestsWithState = new ArrayList<>(queuedRequestsWithState);
+    sortedQueuedRequestsWithState.sort(BaragonRequestWorker.queuedRequestComparator());
+
+    assertEquals(queuedRequestsWithState.get(1), sortedQueuedRequestsWithState.get(0));
+    assertEquals(queuedRequestsWithState.get(0), sortedQueuedRequestsWithState.get(3));
+  }
+}


### PR DESCRIPTION
This PR sets us up to sort queued requests by the following order:
  1. noValidate & noReload
  2. noValidate *or* noReload
  3. everything else