### PR TITLE
bump google compute client versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,19 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>com.google.oauth-client</groupId>
+        <artifactId>google-oauth-client</artifactId>
+        <version>${dep.google.api-client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-compute</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,7 @@
     <dep.curator.version>4.2.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.5</dep.dropwizard-metrics.version>
     <dep.findbugs.jsr.version>3.0.2</dep.findbugs.jsr.version>
-    <dep.google.api-client.version>1.25.0</dep.google.api-client.version>
-    <dep.google.apis.version>v1-rev214-1.25.0</dep.google.apis.version>
+    <dep.google.clients.version>1.25.0</dep.google.clients.version>
     <dep.guava.version>25.0-jre</dep.guava.version>
     <dep.hibernate-validator.version>5.4.3.Final</dep.hibernate-validator.version>
     <dep.hk2.version>2.5.0-b63</dep.hk2.version>
@@ -82,7 +81,7 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>${dep.google.api-client.version}</version>
+        <version>${dep.google.clients.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -98,7 +97,7 @@
       <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
-        <version>${dep.google.api-client.version}</version>
+        <version>${dep.google.clients.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -110,7 +109,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-compute</artifactId>
-        <version>${dep.google.apis.version}</version>
+        <version>v1-rev214-${dep.google.clients.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -127,7 +126,7 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>${dep.google.api-client.version}</version>
+        <version>${dep.google.clients.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     <dep.curator.version>4.2.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.5</dep.dropwizard-metrics.version>
     <dep.findbugs.jsr.version>3.0.2</dep.findbugs.jsr.version>
-    <dep.google.api-client.version>1.23.0</dep.google.api-client.version>
-    <dep.google.apis.version>beta-rev76-1.23.0</dep.google.apis.version>
+    <dep.google.api-client.version>1.29.2</dep.google.api-client.version>
+    <dep.google.apis.version>v1-rev214-1.25.0</dep.google.apis.version>
     <dep.guava.version>25.0-jre</dep.guava.version>
     <dep.hibernate-validator.version>5.4.3.Final</dep.hibernate-validator.version>
     <dep.hk2.version>2.5.0-b63</dep.hk2.version>
@@ -80,6 +80,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-compat-qual</artifactId>
+        <version>2.5.2</version> <!-- for google clients -->
+      </dependency>
+
+      <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
         <version>${dep.google.api-client.version}</version>
@@ -88,12 +94,22 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava-jdk5</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-compute</artifactId>
         <version>${dep.google.apis.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -105,11 +121,23 @@
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
         <version>${dep.google.api-client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson2</artifactId>
         <version>${dep.google.api-client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dep.curator.version>4.2.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.5</dep.dropwizard-metrics.version>
     <dep.findbugs.jsr.version>3.0.2</dep.findbugs.jsr.version>
-    <dep.google.api-client.version>1.29.2</dep.google.api-client.version>
+    <dep.google.api-client.version>1.25.0</dep.google.api-client.version>
     <dep.google.apis.version>v1-rev214-1.25.0</dep.google.apis.version>
     <dep.guava.version>25.0-jre</dep.guava.version>
     <dep.hibernate-validator.version>5.4.3.Final</dep.hibernate-validator.version>
@@ -77,12 +77,6 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>3.1.9</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.checkerframework</groupId>
-        <artifactId>checker-compat-qual</artifactId>
-        <version>2.5.2</version> <!-- for google clients -->
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Ran into some odd NoClassDef issues with the previous ones after recent basepom upgrade.