### PR TITLE
Update batching logic with additional checks for in-flight services

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -316,7 +316,7 @@ public class BaragonRequestWorker implements Runnable {
         LOG.debug("Processing {} BaragonRequests which don't modify a BaragonService", nonServiceChanges.size());
         handleResultStates(handleQueuedRequests(hydratedNonServiceChanges));
 
-        queuedRequests.removeAll(hydratedNonServiceChanges);
+        queuedRequests.removeAll(nonServiceChanges);
         inProgressServices.addAll(hydratedNonServiceChanges.stream().map((q) -> q.getQueuedRequestId().getServiceId()).collect(Collectors.toSet()));
 
         // Now send off the service change requests, after filtering for services already in flight
@@ -334,7 +334,7 @@ public class BaragonRequestWorker implements Runnable {
         LOG.debug("Processing {} BaragonRequests which modify a BaragonService", serviceChanges.size());
         handleResultStates(handleQueuedRequests(hydratedServiceChanges));
 
-        queuedRequests.removeAll(hydratedServiceChanges);
+        queuedRequests.removeAll(serviceChanges);
         inProgressServices.addAll(hydratedServiceChanges.stream().map((q) -> q.getQueuedRequestId().getServiceId()).collect(Collectors.toSet()));
 
         // ...and repeat until we've processed up to the limit of requests

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -306,7 +306,6 @@ public class BaragonRequestWorker implements Runnable {
             .filter((q) -> {
               if (inProgressServices.contains(q.getQueuedRequestId().getServiceId())) {
                 LOG.info("Skipping {} because {} already has an in progress request", q.getQueuedRequestId().getRequestId(), q.getQueuedRequestId().getServiceId());
-                nonServiceChanges.remove(q);
                 return false;
               }
               return true;
@@ -318,7 +317,7 @@ public class BaragonRequestWorker implements Runnable {
         handleResultStates(handleQueuedRequests(hydratedServiceChanges));
 
         queuedRequests.removeAll(nonServiceChanges);
-        queuedRequests.removeAll(serviceChanges);
+        queuedRequests.removeAll(hydratedServiceChanges);
 
         // ...and repeat until we've processed up to the limit of requests
       }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -283,6 +283,15 @@ public class BaragonRequestWorker implements Runnable {
         ArrayList<QueuedRequestWithState> nonServiceChanges = new ArrayList<>();
         ArrayList<QueuedRequestWithState> serviceChanges = new ArrayList<>();
 
+        // First process results for any requests that were already in-flight
+        List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
+            .filter((q) -> q.getCurrentState().isInFlight())
+            .collect(Collectors.toList());
+        LOG.debug("Processing {} BaragonRequests which are already in-flight", inFlightRequests.size());
+        handleResultStates(handleQueuedRequests(inFlightRequests));
+        queuedRequests.removeAll(inFlightRequests);
+
+        // Build the batches of requests to be sent to agents
         added = collectRequests(added, queuedRequests, nonServiceChanges, serviceChanges);
 
         // Now take the list of non-service-change requests,

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -268,14 +268,22 @@ public class BaragonRequestWorker implements Runnable {
           .filter((q) -> q.getCurrentState().isInFlight())
           .map((q) -> q.getQueuedRequestId().getServiceId())
           .collect(Collectors.toSet());
+
       final Set<QueuedRequestWithState> removedForCurrentInFlightRequest = queuedRequests.stream()
           .filter((q) -> inProgressServices.contains(q.getQueuedRequestId().getServiceId()) && !q.getCurrentState().isInFlight())
           .collect(Collectors.toSet());
       if (!inProgressServices.isEmpty()) {
         LOG.info("Skipping new updates for services {} due to current in-flight updates", String.join(",", inProgressServices));
       }
-
       queuedRequests.removeAll(removedForCurrentInFlightRequest);
+
+      // First process results for any requests that were already in-flight
+      List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
+          .filter((q) -> q.getCurrentState().isInFlight())
+          .collect(Collectors.toList());
+      LOG.debug("Processing {} BaragonRequests which are already in-flight", inFlightRequests.size());
+      handleResultStates(handleQueuedRequests(inFlightRequests));
+      queuedRequests.removeAll(inFlightRequests);
 
       int added = 0;
 
@@ -283,20 +291,20 @@ public class BaragonRequestWorker implements Runnable {
         ArrayList<QueuedRequestWithState> nonServiceChanges = new ArrayList<>();
         ArrayList<QueuedRequestWithState> serviceChanges = new ArrayList<>();
 
-        // First process results for any requests that were already in-flight
-        List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
-            .filter((q) -> q.getCurrentState().isInFlight())
-            .collect(Collectors.toList());
-        LOG.debug("Processing {} BaragonRequests which are already in-flight", inFlightRequests.size());
-        handleResultStates(handleQueuedRequests(inFlightRequests));
-        queuedRequests.removeAll(inFlightRequests);
-
         // Build the batches of requests to be sent to agents
         added = collectRequests(added, queuedRequests, nonServiceChanges, serviceChanges);
 
         // Now take the list of non-service-change requests,
         // and sort them such that the quicker noValidate / noReload requests come first.
         List<QueuedRequestWithState> hydratedNonServiceChanges = nonServiceChanges.stream()
+            .filter((q) -> {
+              // Filter here as well since the Set has changed by the second run of the while loop
+              if (inProgressServices.contains(q.getQueuedRequestId().getServiceId())) {
+                LOG.info("Skipping {} because {} already has an in progress request", q.getQueuedRequestId().getRequestId(), q.getQueuedRequestId().getServiceId());
+                return false;
+              }
+              return true;
+            })
             .map(someRequest -> new MaybeAdjustedRequest(someRequest, false))
             .map(this::setNoValidateIfRequestRemovesUpstreamsOnly)
             .map(this::preResolveDNS)
@@ -332,7 +340,7 @@ public class BaragonRequestWorker implements Runnable {
       }
     } catch (Exception e) {
       LOG.warn("Caught exception", e);
-      exceptionNotifier.notify(e, Collections.<String, String>emptyMap());
+      exceptionNotifier.notify(e, Collections.emptyMap());
     } finally {
       LOG.debug("Finished poller loop.");
     }

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -306,6 +306,7 @@ public class BaragonRequestWorker implements Runnable {
             .filter((q) -> {
               if (inProgressServices.contains(q.getQueuedRequestId().getServiceId())) {
                 LOG.info("Skipping {} because {} already has an in progress request", q.getQueuedRequestId().getRequestId(), q.getQueuedRequestId().getServiceId());
+                nonServiceChanges.remove(q);
                 return false;
               }
               return true;

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -299,8 +299,17 @@ public class BaragonRequestWorker implements Runnable {
         LOG.debug("Processing {} BaragonRequests which don't modify a BaragonService", nonServiceChanges.size());
         handleResultStates(handleQueuedRequests(hydratedNonServiceChanges));
 
-        // Now send off the service change requests.
+        inProgressServices.addAll(hydratedNonServiceChanges.stream().map((q) -> q.getQueuedRequestId().getServiceId()).collect(Collectors.toSet()));
+
+        // Now send off the service change requests, after filtering for services already in flight
         List<QueuedRequestWithState> hydratedServiceChanges = serviceChanges.stream()
+            .filter((q) -> {
+              if (inProgressServices.contains(q.getQueuedRequestId().getServiceId())) {
+                LOG.info("Skipping {} because {} already has an in progress request", q.getQueuedRequestId().getRequestId(), q.getQueuedRequestId().getServiceId());
+                return false;
+              }
+              return true;
+            })
             .sorted(queuedRequestComparator())
             .collect(Collectors.toList());
 

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -316,6 +316,7 @@ public class BaragonRequestWorker implements Runnable {
         LOG.debug("Processing {} BaragonRequests which don't modify a BaragonService", nonServiceChanges.size());
         handleResultStates(handleQueuedRequests(hydratedNonServiceChanges));
 
+        queuedRequests.removeAll(hydratedNonServiceChanges);
         inProgressServices.addAll(hydratedNonServiceChanges.stream().map((q) -> q.getQueuedRequestId().getServiceId()).collect(Collectors.toSet()));
 
         // Now send off the service change requests, after filtering for services already in flight
@@ -333,8 +334,8 @@ public class BaragonRequestWorker implements Runnable {
         LOG.debug("Processing {} BaragonRequests which modify a BaragonService", serviceChanges.size());
         handleResultStates(handleQueuedRequests(hydratedServiceChanges));
 
-        queuedRequests.removeAll(nonServiceChanges);
         queuedRequests.removeAll(hydratedServiceChanges);
+        inProgressServices.addAll(hydratedServiceChanges.stream().map((q) -> q.getQueuedRequestId().getServiceId()).collect(Collectors.toSet()));
 
         // ...and repeat until we've processed up to the limit of requests
       }


### PR DESCRIPTION
We can still hit race conditions if two requests come in for the same service, with one being a batch boundary and one not. https://github.com/HubSpot/Baragon/pull/324 _almost_ caught this, but the list needs to be re-updated and checked between the non-service-change and service-change calls