### PR TITLE
Add poller to reconcile agent state with service

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -1,8 +1,10 @@
 package com.hubspot.baragon.agent;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -272,8 +274,8 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   @Provides
   @Singleton
   @Named(LOCAL_STATE_ERROR_MESSAGE)
-  public AtomicReference<Optional<String>> providesLocalStateErrorMessage() {
-    return new AtomicReference<>(Optional.absent());
+  public Set<String> providesLocalStateErrorMessage() {
+    return new HashSet<>();
   }
 
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -3,6 +3,7 @@ package com.hubspot.baragon.agent;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -63,6 +64,7 @@ import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.models.BaragonAgentEc2Metadata;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonAgentState;
+import com.hubspot.baragon.models.BasicServiceContext;
 import com.hubspot.baragon.utils.JavaUtils;
 import com.hubspot.baragon.utils.UpstreamResolver;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
@@ -83,6 +85,8 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   public static final String DEFAULT_TEMPLATE_NAME = "default";
   public static final String BARAGON_AGENT_HTTP_CLIENT = "baragon.agent.http.client";
   public static final String CONFIG_ERROR_MESSAGE = "baragon.agent.config.error.message";
+  public static final String LOCAL_STATE_ERROR_MESSAGE = "baragon.agent.local.state.error.message";
+  public static final String INTERNAL_STATE_CACHE = "baragon.agent.internal.state.cache";
 
   private static final Pattern FORMAT_PATTERN = Pattern.compile("[^%]%([+-]?\\d*.?\\d*)?[sdf]");
 
@@ -262,7 +266,14 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   @Singleton
   @Named(CONFIG_ERROR_MESSAGE)
   public AtomicReference<Optional<String>> providesConfigErrorMessage() {
-    return new AtomicReference<>();
+    return new AtomicReference<>(Optional.absent());
+  }
+
+  @Provides
+  @Singleton
+  @Named(LOCAL_STATE_ERROR_MESSAGE)
+  public AtomicReference<Optional<String>> providesLocalStateErrorMessage() {
+    return new AtomicReference<>(Optional.absent());
   }
 
 
@@ -270,7 +281,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   @Singleton
   @Named(AGENT_SCHEDULED_EXECUTOR)
   public ScheduledExecutorService providesScheduledExecutor() {
-    return Executors.newScheduledThreadPool(2);
+    return Executors.newScheduledThreadPool(3);
   }
 
   @Provides
@@ -314,5 +325,12 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   @Singleton
   public UpstreamResolver provideUpstreamResolver(BaragonAgentConfiguration config) {
     return new UpstreamResolver(config.getMaxResolveCacheSize(), config.getExpireResolveCacheAfterDays());
+  }
+
+  @Provides
+  @Singleton
+  @Named(INTERNAL_STATE_CACHE)
+  public Map<String, BasicServiceContext> provideStateCache() {
+    return new ConcurrentHashMap<>();
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -103,6 +103,9 @@ public class BaragonAgentConfiguration extends Configuration {
   @JsonProperty("configCheckIntervalSecs")
   private int configCheckIntervalSecs = 60;
 
+  @JsonProperty("stateCheckIntervalSecs")
+  private int stateCheckIntervalSecs = 600;
+
   @JsonProperty("saveFailedConfigs")
   private boolean saveFailedConfigs = false;
 
@@ -135,6 +138,9 @@ public class BaragonAgentConfiguration extends Configuration {
 
   @JsonProperty
   private long expireResolveCacheAfterDays = 30;
+
+  @JsonProperty
+  private boolean enablePollingFileValidation = false;
 
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
@@ -300,6 +306,14 @@ public class BaragonAgentConfiguration extends Configuration {
     this.configCheckIntervalSecs = configCheckIntervalSecs;
   }
 
+  public int getStateCheckIntervalSecs() {
+    return stateCheckIntervalSecs;
+  }
+
+  public void setStateCheckIntervalSecs(int stateCheckIntervalSecs) {
+    this.stateCheckIntervalSecs = stateCheckIntervalSecs;
+  }
+
   public boolean isSaveFailedConfigs() {
     return saveFailedConfigs;
   }
@@ -394,5 +408,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setExpireResolveCacheAfterDays(long expireResolveCacheAfterDays) {
     this.expireResolveCacheAfterDays = expireResolveCacheAfterDays;
+  }
+
+  public boolean isEnablePollingFileValidation() {
+    return enablePollingFileValidation;
+  }
+
+  public void setEnablePollingFileValidation(boolean enablePollingFileValidation) {
+    this.enablePollingFileValidation = enablePollingFileValidation;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -140,7 +140,7 @@ public class BaragonAgentConfiguration extends Configuration {
   private long expireResolveCacheAfterDays = 30;
 
   @JsonProperty
-  private boolean enablePollingFileValidation = false;
+  private boolean enablePollingStateValidation = false;
 
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
@@ -410,11 +410,11 @@ public class BaragonAgentConfiguration extends Configuration {
     this.expireResolveCacheAfterDays = expireResolveCacheAfterDays;
   }
 
-  public boolean isEnablePollingFileValidation() {
-    return enablePollingFileValidation;
+  public boolean isEnablePollingStateValidation() {
+    return enablePollingStateValidation;
   }
 
-  public void setEnablePollingFileValidation(boolean enablePollingFileValidation) {
-    this.enablePollingFileValidation = enablePollingFileValidation;
+  public void setEnablePollingStateValidation(boolean enablePollingStateValidation) {
+    this.enablePollingStateValidation = enablePollingStateValidation;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Optional;
@@ -42,7 +43,7 @@ public class InternalStateChecker implements Runnable {
       }
       Collection<UpstreamInfo> existingUpstreams = stateDatastore.getUpstreams(serviceId);
       BasicServiceContext datastoreContext = new BasicServiceContext(maybeService.get(), existingUpstreams);
-      if (!datastoreContext.equals(context)) {
+      if (!datastoreContext.equals(context) && System.currentTimeMillis() - context.getTimestamp() > TimeUnit.SECONDS.toMillis(60)) {
         invalidServiceMessages.add(String.format("Agent context for %s does not match baragon state (Agent: %s, Service: %s)", serviceId, context, datastoreContext));
       }
     });

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
@@ -1,0 +1,57 @@
+package com.hubspot.baragon.agent.healthcheck;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.hubspot.baragon.agent.BaragonAgentServiceModule;
+import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.BasicServiceContext;
+import com.hubspot.baragon.models.UpstreamInfo;
+
+@Singleton
+public class InternalStateChecker implements Runnable {
+  private final BaragonStateDatastore stateDatastore;
+  private final Map<String, BasicServiceContext> internalStateCache;
+  private final AtomicReference<Optional<String>> stateErrorMessage;
+
+  @Inject
+  public InternalStateChecker(BaragonStateDatastore stateDatastore,
+                              @Named(BaragonAgentServiceModule.INTERNAL_STATE_CACHE) Map<String, BasicServiceContext> internalStateCache,
+                              @Named(BaragonAgentServiceModule.LOCAL_STATE_ERROR_MESSAGE) AtomicReference<Optional<String>> stateErrorMessage) {
+    this.stateDatastore = stateDatastore;
+    this.internalStateCache = internalStateCache;
+    this.stateErrorMessage = stateErrorMessage;
+  }
+
+  @Override
+  public void run() {
+    Set<String> invalidServiceMessages = new HashSet<>();
+    internalStateCache.forEach((serviceId, context) -> {
+      Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+      if (!maybeService.isPresent()) {
+        invalidServiceMessages.add(String.format("%s no longer exists in state datastore, but exists in agent", serviceId));
+        return;
+      }
+      Collection<UpstreamInfo> existingUpstreams = stateDatastore.getUpstreams(serviceId);
+      BasicServiceContext datastoreContext = new BasicServiceContext(maybeService.get(), existingUpstreams);
+      if (!datastoreContext.equals(context)) {
+        invalidServiceMessages.add(String.format("Agent context for %s does not match baragon state (Agent: %s, Service: %s)", serviceId, context, datastoreContext));
+      }
+    });
+    if (invalidServiceMessages.isEmpty()) {
+      stateErrorMessage.set(Optional.absent());
+    } else {
+      stateErrorMessage.set(Optional.of(
+          String.join("\n", invalidServiceMessages)
+      ));
+    }
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
@@ -35,6 +35,7 @@ public class InternalStateChecker implements Runnable {
   @Override
   public void run() {
     Set<String> invalidServiceMessages = new HashSet<>();
+    long now = System.currentTimeMillis();
     internalStateCache.forEach((serviceId, context) -> {
       Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
       if (!maybeService.isPresent()) {
@@ -43,7 +44,7 @@ public class InternalStateChecker implements Runnable {
       }
       Collection<UpstreamInfo> existingUpstreams = stateDatastore.getUpstreams(serviceId);
       BasicServiceContext datastoreContext = new BasicServiceContext(maybeService.get(), existingUpstreams);
-      if (!datastoreContext.equals(context) && System.currentTimeMillis() - context.getTimestamp() > TimeUnit.SECONDS.toMillis(60)) {
+      if (!datastoreContext.equals(context) && now - context.getTimestamp() > TimeUnit.SECONDS.toMillis(60)) {
         invalidServiceMessages.add(String.format("Agent context for %s does not match baragon state (Agent: %s, Service: %s)", serviceId, context, datastoreContext));
       }
     });

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/FilesystemConfigHelper.java
@@ -155,14 +155,14 @@ public class FilesystemConfigHelper {
     LOG.info("Writing finished for {}", service.getServiceId());
   }
 
-  public void bootstrapApplyCheck(List<Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>>> applied) {
+  public void bootstrapApplyCheck(List<Pair<ServiceContext, Collection<BaragonConfigFile>>> applied) {
     LOG.info("Going to check the configs");
     try {
       adapter.checkConfigs();
     } catch (Exception e) {
       LOG.error("Caught exception while checking configs", e);
-      applied.stream().forEach(item -> {
-        final ServiceContext context = item.get().getKey();
+      applied.forEach(item -> {
+        final ServiceContext context = item.getKey();
         final BaragonService service = context.getService();
         saveAsFailed(service);
         LOG.info("Marked {}: as failed", service.getServiceId());

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -108,8 +108,10 @@ public class BootstrapManaged implements Managed {
     LOG.info("Starting config checker");
     configCheckerFuture = executorService.scheduleAtFixedRate(configChecker, 0, configuration.getConfigCheckIntervalSecs(), TimeUnit.SECONDS);
 
-    LOG.info("Starting state reconciliation checker");
-    stateCheckerFuture = executorService.scheduleAtFixedRate(internalStateChecker, configuration.getStateCheckIntervalSecs(), configuration.getStateCheckIntervalSecs(), TimeUnit.SECONDS);
+    if (configuration.isEnablePollingStateValidation()) {
+      LOG.info("Starting state reconciliation checker");
+      stateCheckerFuture = executorService.scheduleAtFixedRate(internalStateChecker, configuration.getStateCheckIntervalSecs(), configuration.getStateCheckIntervalSecs(), TimeUnit.SECONDS);
+    }
 
     lifecycleHelper.writeStateFileIfConfigured();
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -15,6 +15,7 @@ import com.google.inject.name.Named;
 import com.hubspot.baragon.agent.BaragonAgentServiceModule;
 import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
 import com.hubspot.baragon.agent.healthcheck.ConfigChecker;
+import com.hubspot.baragon.agent.healthcheck.InternalStateChecker;
 import com.hubspot.baragon.agent.listeners.ResyncListener;
 import com.hubspot.baragon.agent.workers.AgentHeartbeatWorker;
 import com.hubspot.baragon.data.BaragonKnownAgentsDatastore;
@@ -39,10 +40,12 @@ public class BootstrapManaged implements Managed {
   private final CuratorFramework curatorFramework;
   private final ResyncListener resyncListener;
   private final ConfigChecker configChecker;
+  private final InternalStateChecker internalStateChecker;
   private final AtomicReference<BaragonAgentState> agentState;
 
   private ScheduledFuture<?> requestWorkerFuture = null;
   private ScheduledFuture<?> configCheckerFuture = null;
+  private ScheduledFuture<?> stateCheckerFuture = null;
 
   @Inject
   public BootstrapManaged(BaragonKnownAgentsDatastore knownAgentsDatastore,
@@ -55,6 +58,7 @@ public class BootstrapManaged implements Managed {
                           ResyncListener resyncListener,
                           ConfigChecker configChecker,
                           AtomicReference<BaragonAgentState> agentState,
+                          InternalStateChecker internalStateChecker,
                           @Named(BaragonAgentServiceModule.AGENT_SCHEDULED_EXECUTOR) ScheduledExecutorService executorService,
                           @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch) {
     this.configuration = configuration;
@@ -68,6 +72,7 @@ public class BootstrapManaged implements Managed {
     this.agentHeartbeatWorker = agentHeartbeatWorker;
     this.lifecycleHelper = lifecycleHelper;
     this.configChecker = configChecker;
+    this.internalStateChecker = internalStateChecker;
     this.agentState = agentState;
   }
 
@@ -103,6 +108,9 @@ public class BootstrapManaged implements Managed {
     LOG.info("Starting config checker");
     configCheckerFuture = executorService.scheduleAtFixedRate(configChecker, 0, configuration.getConfigCheckIntervalSecs(), TimeUnit.SECONDS);
 
+    LOG.info("Starting state reconciliation checker");
+    stateCheckerFuture = executorService.scheduleAtFixedRate(internalStateChecker, configuration.getStateCheckIntervalSecs(), configuration.getStateCheckIntervalSecs(), TimeUnit.SECONDS)
+
     lifecycleHelper.writeStateFileIfConfigured();
 
     agentState.set(BaragonAgentState.ACCEPTING);
@@ -111,5 +119,11 @@ public class BootstrapManaged implements Managed {
   @Override
   public void stop() throws Exception {
     lifecycleHelper.shutdown();
+    if (requestWorkerFuture != null) {
+      requestWorkerFuture.cancel(true);
+    }
+    if (configCheckerFuture != null) {
+      configCheckerFuture.cancel(true);
+    }
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/managed/BootstrapManaged.java
@@ -109,7 +109,7 @@ public class BootstrapManaged implements Managed {
     configCheckerFuture = executorService.scheduleAtFixedRate(configChecker, 0, configuration.getConfigCheckIntervalSecs(), TimeUnit.SECONDS);
 
     LOG.info("Starting state reconciliation checker");
-    stateCheckerFuture = executorService.scheduleAtFixedRate(internalStateChecker, configuration.getStateCheckIntervalSecs(), configuration.getStateCheckIntervalSecs(), TimeUnit.SECONDS)
+    stateCheckerFuture = executorService.scheduleAtFixedRate(internalStateChecker, configuration.getStateCheckIntervalSecs(), configuration.getStateCheckIntervalSecs(), TimeUnit.SECONDS);
 
     lifecycleHelper.writeStateFileIfConfigured();
 
@@ -124,6 +124,9 @@ public class BootstrapManaged implements Managed {
     }
     if (configCheckerFuture != null) {
       configCheckerFuture.cancel(true);
+    }
+    if (stateCheckerFuture != null) {
+      stateCheckerFuture.cancel(true);
     }
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/StatusResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/StatusResource.java
@@ -1,13 +1,18 @@
 package com.hubspot.baragon.agent.resources;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.state.ConnectionState;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
@@ -21,8 +26,7 @@ import com.hubspot.baragon.exceptions.InvalidConfigException;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
 import com.hubspot.baragon.models.BaragonAgentState;
 import com.hubspot.baragon.models.BaragonAgentStatus;
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-import org.apache.curator.framework.state.ConnectionState;
+import com.hubspot.baragon.models.BasicServiceContext;
 
 @Path("/status")
 @Produces(MediaType.APPLICATION_JSON)
@@ -34,7 +38,9 @@ public class StatusResource {
   private final AtomicReference<ConnectionState> connectionState;
   private final BaragonAgentMetadata agentMetadata;
   private final AtomicReference<Optional<String>> errorMessage;
+  private final AtomicReference<Optional<String>> stateErrorMessage;
   private final AtomicReference<BaragonAgentState> agentState;
+  private final Map<String, BasicServiceContext> internalStateCache;
 
   @Inject
   public StatusResource(LocalLbAdapter adapter,
@@ -44,7 +50,9 @@ public class StatusResource {
                         @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch,
                         @Named(BaragonAgentServiceModule.AGENT_MOST_RECENT_REQUEST_ID) AtomicReference<String> mostRecentRequestId,
                         @Named(BaragonDataModule.BARAGON_ZK_CONNECTION_STATE) AtomicReference<ConnectionState> connectionState,
-                        @Named(BaragonAgentServiceModule.CONFIG_ERROR_MESSAGE) AtomicReference<Optional<String>> errorMessage) {
+                        @Named(BaragonAgentServiceModule.CONFIG_ERROR_MESSAGE) AtomicReference<Optional<String>> errorMessage,
+                        @Named(BaragonAgentServiceModule.LOCAL_STATE_ERROR_MESSAGE) AtomicReference<Optional<String>> stateErrorMessage,
+                        @Named(BaragonAgentServiceModule.INTERNAL_STATE_CACHE) Map<String, BasicServiceContext> internalStateCache) {
     this.adapter = adapter;
     this.loadBalancerConfiguration = loadBalancerConfiguration;
     this.leaderLatch = leaderLatch;
@@ -52,7 +60,9 @@ public class StatusResource {
     this.connectionState = connectionState;
     this.agentMetadata = agentMetadata;
     this.errorMessage = errorMessage;
+    this.stateErrorMessage = stateErrorMessage;
     this.agentState = agentState;
+    this.internalStateCache = internalStateCache;
   }
 
   @GET
@@ -71,8 +81,26 @@ public class StatusResource {
 
     final String connectionStateString = currentConnectionState == null ? "UNKNOWN" : currentConnectionState.name();
 
-    Optional<String> currentErrorMessage = errorMessage.get();
+    Optional<String> errMessage = getErrorMessage();
 
-    return new BaragonAgentStatus(loadBalancerConfiguration.getName(), !currentErrorMessage.isPresent(), currentErrorMessage, leaderLatch.hasLeadership(), mostRecentRequestId.get(), connectionStateString, agentMetadata, agentState.get());
+    return new BaragonAgentStatus(loadBalancerConfiguration.getName(), !errMessage.isPresent(), errMessage, leaderLatch.hasLeadership(), mostRecentRequestId.get(), connectionStateString, agentMetadata, agentState.get());
+  }
+
+  private Optional<String> getErrorMessage() {
+    Optional<String> currentErrorMessage = errorMessage.get();
+    Optional<String> currentStateError = stateErrorMessage.get();
+    if (currentErrorMessage.isPresent() || currentStateError.isPresent()) {
+      return Optional.of(
+          String.format("State Error: %s, Config Error: %s", currentStateError.or(""), currentErrorMessage.or(""))
+      );
+    } else {
+      return Optional.absent();
+    }
+  }
+
+  @GET
+  @Path("/{serviceId}")
+  public Optional<BasicServiceContext> getServiceConfig(@PathParam("serviceId") String serviceId) {
+    return Optional.fromNullable(internalStateCache.get(serviceId));
   }
 }

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentStatus.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentStatus.java
@@ -1,5 +1,7 @@
 package com.hubspot.baragon.models;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,6 +12,7 @@ public class BaragonAgentStatus {
   private final String group;
   private final boolean validConfigs;
   private final Optional<String> errorMessage;
+  private final Set<String> stateErrors;
   private final boolean leader;
   private final String mostRecentRequestId;
   private final String zookeeperState;
@@ -24,7 +27,8 @@ public class BaragonAgentStatus {
                             @JsonProperty("mostRecentRequestId") String mostRecentRequestId,
                             @JsonProperty("zookeeperState") String zookeeperState,
                             @JsonProperty("agentInfo") BaragonAgentMetadata agentInfo,
-                            @JsonProperty("agentState") BaragonAgentState agentState) {
+                            @JsonProperty("agentState") BaragonAgentState agentState,
+                            @JsonProperty("stateErrors") Set<String> stateErrors) {
     this.group = group;
     this.validConfigs = validConfigs;
     this.errorMessage = errorMessage;
@@ -33,6 +37,7 @@ public class BaragonAgentStatus {
     this.zookeeperState = zookeeperState;
     this.agentInfo = agentInfo;
     this.agentState = agentState;
+    this.stateErrors = stateErrors;
   }
 
   public String getGroup() {

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BasicServiceContext.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BasicServiceContext.java
@@ -1,0 +1,79 @@
+package com.hubspot.baragon.models;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BasicServiceContext {
+  private final BaragonService service;
+  private final Collection<UpstreamInfo> upstreams;
+
+  @JsonCreator
+  public BasicServiceContext(@JsonProperty("service") BaragonService service,
+                             @JsonProperty("upstreams") Collection<UpstreamInfo> upstreams) {
+    this.service = service;
+    this.upstreams = MoreObjects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList());
+  }
+
+  public BaragonService getService() {
+    return service;
+  }
+
+  public Collection<UpstreamInfo> getUpstreams() {
+    return upstreams;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BasicServiceContext that = (BasicServiceContext) o;
+
+    if (!service.equals(that.service)) {
+      return false;
+    }
+    if (upstreams.size() != that.upstreams.size()) {
+      return false;
+    }
+
+    for (UpstreamInfo upstreamInfo : upstreams) {
+      boolean foundMatching = false;
+      for (UpstreamInfo otherUpstream : that.upstreams) {
+        if (UpstreamInfo.upstreamAndGroupMatches(upstreamInfo, otherUpstream)) {
+          foundMatching = true;
+          break;
+        }
+      }
+      if (!foundMatching) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = service.hashCode();
+    result = 31 * result + upstreams.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ServiceContext [" +
+        "service=" + service +
+        ", upstreams=" + upstreams +
+        ']';
+  }
+}

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BasicServiceContext.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BasicServiceContext.java
@@ -12,12 +12,20 @@ import com.google.common.base.MoreObjects;
 public class BasicServiceContext {
   private final BaragonService service;
   private final Collection<UpstreamInfo> upstreams;
+  private final Long timestamp;
 
   @JsonCreator
   public BasicServiceContext(@JsonProperty("service") BaragonService service,
-                             @JsonProperty("upstreams") Collection<UpstreamInfo> upstreams) {
+                             @JsonProperty("upstreams") Collection<UpstreamInfo> upstreams,
+                             @JsonProperty("timestamp") Long timestamp) {
     this.service = service;
-    this.upstreams = MoreObjects.firstNonNull(upstreams, Collections.<UpstreamInfo>emptyList());
+    this.upstreams = MoreObjects.firstNonNull(upstreams, Collections.emptyList());
+    this.timestamp = timestamp;
+  }
+
+  public BasicServiceContext(@JsonProperty("service") BaragonService service,
+                             @JsonProperty("upstreams") Collection<UpstreamInfo> upstreams) {
+    this(service, upstreams, System.currentTimeMillis());
   }
 
   public BaragonService getService() {
@@ -26,6 +34,10 @@ public class BasicServiceContext {
 
   public Collection<UpstreamInfo> getUpstreams() {
     return upstreams;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
   }
 
   @Override
@@ -71,9 +83,10 @@ public class BasicServiceContext {
 
   @Override
   public String toString() {
-    return "ServiceContext [" +
+    return "BasicServiceContext{" +
         "service=" + service +
         ", upstreams=" + upstreams +
-        ']';
+        ", timestamp=" + timestamp +
+        '}';
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonStateDatastore.java
@@ -78,7 +78,7 @@ public class BaragonStateDatastore extends AbstractDataStore {
     return getChildren(String.format(SERVICE_FORMAT, serviceId));
   }
 
-  public Collection<UpstreamInfo> getUpstreams(String serviceId) throws Exception {
+  public Collection<UpstreamInfo> getUpstreams(String serviceId) {
     final Collection<String> upstreamNodes = getUpstreamNodes(serviceId);
     final Collection<UpstreamInfo> upstreams = new ArrayList<>(upstreamNodes.size());
     for (String node : upstreamNodes) {


### PR DESCRIPTION
We fixed the root cause of this in previous bugs, but we still need better monitoring. This adds a poller in the agent that periodically will recheck its own view of state that it has rendered to file against what BaragonService currently says is the state of the world. At the moment I'm doing this as smaller direct calls to zk so that a ton of agents all calling in for state don't overwhelm service. Still need to determine if this is fast enough to avoid false positives from state being updated while the check is in progress.