### PR TITLE
Service locking on agent

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -129,6 +129,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     binder.bind(FilesystemConfigHelper.class).in(Scopes.SINGLETON);
     binder.bind(AgentHeartbeatWorker.class).in(Scopes.SINGLETON);
     binder.bind(InternalStateChecker.class).in(Scopes.SINGLETON);
+    binder.bind(BaragonServiceLock.class).in(Scopes.SINGLETON);
 
     binder.bind(new TypeLiteral<Map<String, BasicServiceContext>>() {})
         .annotatedWith(Names.named(INTERNAL_STATE_CACHE))

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonServiceLock.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonServiceLock.java
@@ -1,0 +1,80 @@
+package com.hubspot.baragon.agent;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class BaragonServiceLock {
+  private static final Logger LOG = LoggerFactory.getLogger(BaragonServiceLock.class);
+
+  private final ConcurrentHashMap<String, ReentrantLock> serviceLocks;
+
+  @Inject
+  public BaragonServiceLock() {
+    this.serviceLocks = new ConcurrentHashMap<>();
+  }
+
+  public void runWithServiceLock(Runnable function, String serviceId, String name) {
+    long startWaiting = System.currentTimeMillis();
+    ReentrantLock lock = serviceLocks.computeIfAbsent(serviceId, (r) -> new ReentrantLock());
+    lock.lock();
+    long start = System.currentTimeMillis();
+    LOG.debug("({}) Acquired lock on {} after {}ms", name, serviceId, start - startWaiting);
+    try {
+      function.run();
+    } finally {
+      lock.unlock();
+      LOG.debug("({}) Unlocked {} after {}ms", name, serviceId, System.currentTimeMillis() - start);
+    }
+  }
+
+  public <T> T runWithServiceLockAndReturn(Callable<T> function, String serviceId, String name) {
+    long startWaiting = System.currentTimeMillis();
+    ReentrantLock lock = serviceLocks.computeIfAbsent(serviceId, (r) -> new ReentrantLock());
+    lock.lock();
+    long start = System.currentTimeMillis();
+    LOG.debug("({}) Acquired lock on {} after {}ms", name, serviceId, start - startWaiting);
+    try {
+      return function.call();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      lock.unlock();
+      LOG.debug("({}) Unlocked {} after {}ms", name, serviceId, System.currentTimeMillis() - start);
+    }
+  }
+
+  public <T> T runWithServiceLocksAndReturn(Callable<T> function, Set<String> serviceIds, String name) {
+    long startWaiting = System.currentTimeMillis();
+    ReentrantLock[] held = new ReentrantLock[serviceIds.size()];
+    int i = 0;
+    for (String serviceId : serviceIds) {
+      held[i] = serviceLocks.computeIfAbsent(serviceId, (r) -> new ReentrantLock());
+      i++;
+    }
+    long start = System.currentTimeMillis();
+    LOG.debug("({}) Acquired lock on {} after {}ms", name, serviceIds, start - startWaiting);
+    try {
+      return function.call();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      for (ReentrantLock lock : held) {
+        try {
+          lock.unlock();
+        } catch (Throwable t) {
+          LOG.error("({}) Could not unlock", name, t);
+        }
+      }
+      LOG.debug("({}) Unlocked {} after {}ms", name, serviceIds, System.currentTimeMillis() - start);
+    }
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/kubernetes/BaragonAgentKubernetesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/kubernetes/BaragonAgentKubernetesListener.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.hubspot.baragon.agent.BaragonServiceLock;
 import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
 import com.hubspot.baragon.agent.managers.AgentRequestManager;
 import com.hubspot.baragon.config.KubernetesConfiguration;
@@ -29,18 +30,19 @@ public class BaragonAgentKubernetesListener extends KubernetesListener {
 
   private final BaragonAgentConfiguration agentConfiguration;
   private final AgentRequestManager agentRequestManager;
+  private final BaragonServiceLock serviceLock;
 
   @Inject
   public BaragonAgentKubernetesListener(KubernetesConfiguration kubernetesConfiguration,
                                         BaragonAgentConfiguration agentConfiguration,
                                         AgentRequestManager agentRequestManager,
-                                        BaragonStateDatastore stateDatastore) {
+                                        BaragonStateDatastore stateDatastore,
+                                        BaragonServiceLock serviceLock) {
     super(stateDatastore, kubernetesConfiguration);
     this.agentConfiguration = agentConfiguration;
     this.agentRequestManager = agentRequestManager;
+    this.serviceLock = serviceLock;
   }
-
-  // TODO - lock on all these? On ServiceId?
 
   @Override
   public void processServiceDelete(String serviceId, String upstreamGroup) {
@@ -55,139 +57,20 @@ public class BaragonAgentKubernetesListener extends KubernetesListener {
       return;
     }
 
-    List<UpstreamInfo> existingUpstreams = new ArrayList<>(stateDatastore.getUpstreams(updatedService.getServiceId()));
-    Map<Boolean, List<UpstreamInfo>> partitionedUpstreams = existingUpstreams.stream()
-        .collect(Collectors.partitioningBy((u) -> kubernetesConfiguration.getIgnoreUpstreamGroups().contains(u.getGroup())));
+    serviceLock.runWithServiceLock(() -> {
+      List<UpstreamInfo> existingUpstreams = new ArrayList<>(stateDatastore.getUpstreams(updatedService.getServiceId()));
+      Map<Boolean, List<UpstreamInfo>> partitionedUpstreams = existingUpstreams.stream()
+          .collect(Collectors.partitioningBy((u) -> kubernetesConfiguration.getIgnoreUpstreamGroups().contains(u.getGroup())));
 
-    // K8s integration supports a subset of features, take existing extra options if non-k8s upstreams also present
-    BaragonService relevantService = partitionedUpstreams.get(true).isEmpty() ?
-        updatedService :
-        stateDatastore.getService(updatedService.getServiceId()).or(updatedService);
-    BaragonRequest baragonRequest = new BaragonRequest(
-        String.format("k8s-update-service-%d", System.nanoTime()),
-        relevantService,
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Collections.emptyList(),
-        Optional.absent(),
-        Optional.of(RequestAction.UPDATE),
-        false,
-        false,
-        false,
-        false
-    );
-
-    Map<String, Collection<UpstreamInfo>> upstreamsForUpdate = new HashMap<>();
-    upstreamsForUpdate.put(updatedService.getServiceId(), existingUpstreams);
-
-    agentRequestManager.processRequest(
-        baragonRequest.getLoadBalancerRequestId(),
-        RequestAction.UPDATE,
-        baragonRequest,
-        Optional.absent(),
-        upstreamsForUpdate,
-        false,
-        Optional.absent());
-  }
-
-  @Override
-  public void processUpstreamsUpdate(String serviceId, String upstreamGroup, List<UpstreamInfo> activeUpstreams) {
-    Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
-    if (!maybeService.isPresent()) {
-      LOG.info("No service definition for {}, skipping update", serviceId);
-      LOG.trace("Skipped update {} - {}", serviceId, activeUpstreams);
-      return;
-    }
-    if (!isRelevantUpdate(maybeService.get())) {
-      LOG.debug("Not relevant update for agent's group/domains, skipping ({})", serviceId);
-      LOG.trace("Skipped update {} - {}", serviceId, activeUpstreams);
-      return;
-    }
-
-    Collection<UpstreamInfo> existingUpstreams = stateDatastore.getUpstreams(serviceId);
-
-    List<UpstreamInfo> toRemove = existingUpstreams
-        .stream()
-        .filter((u) -> {
-          boolean groupMatches = u.getGroup().equals(upstreamGroup);
-          if (!groupMatches) {
-            return false;
-          }
-          for (UpstreamInfo active : activeUpstreams) {
-            if (UpstreamInfo.upstreamAndGroupMatches(u, active)) {
-              return false;
-            }
-          }
-          return true;
-        })
-        .collect(Collectors.toList());
-
-    BaragonRequest baragonRequest = new BaragonRequest(
-        String.format("k8s-update-uptreams-%d", System.nanoTime()),
-        maybeService.get(),
-        activeUpstreams,
-        toRemove,
-        Collections.emptyList(),
-        Optional.absent(),
-        Optional.of(RequestAction.UPDATE),
-        false,
-        false,
-        true,
-        false
-    );
-
-    Map<String, Collection<UpstreamInfo>> upstreamsForUpdate = new HashMap<>();
-    upstreamsForUpdate.put(serviceId, existingUpstreams);
-
-    agentRequestManager.processRequest(
-        baragonRequest.getLoadBalancerRequestId(),
-        RequestAction.UPDATE,
-        baragonRequest,
-        Optional.absent(),
-        upstreamsForUpdate,
-        false,
-        Optional.absent());
-  }
-
-  @Override
-  public void processEndpointsDelete(String serviceName, String upstreamGroup) {
-    processDelete(serviceName, upstreamGroup);
-  }
-
-  private boolean isRelevantUpdate(BaragonService updatedService) {
-    boolean isUpdateForGroup = updatedService.getLoadBalancerGroups().contains(agentConfiguration.getLoadBalancerConfiguration().getName());
-    boolean isUpdateForDomain = !Sets.intersection(updatedService.getDomains(), agentConfiguration.getLoadBalancerConfiguration().getDomains()).isEmpty();
-    boolean isUpdateForDefaultDomain = updatedService.getDomains().contains(agentConfiguration.getLoadBalancerConfiguration().getDefaultDomain().or(""));
-    return isUpdateForGroup && (isUpdateForDomain || isUpdateForDefaultDomain);
-  }
-
-  private void processDelete(String serviceId, String upstreamGroup) {
-    Map<Boolean, List<UpstreamInfo>> partitionedUpstreams = stateDatastore.getUpstreams(serviceId)
-        .stream()
-        .collect(Collectors.partitioningBy((u) -> u.getGroup().equals(upstreamGroup)));
-    Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
-    if (partitionedUpstreams.get(false).isEmpty()) {
-      LOG.info("No remaining upstreams for {}, deleting", serviceId);
-      if (maybeService.isPresent()) {
-        BaragonRequest baragonRequest = createDeleteRequest(maybeService.get());
-        agentRequestManager.processRequest(
-            baragonRequest.getLoadBalancerRequestId(),
-            RequestAction.DELETE,
-            baragonRequest,
-            Optional.absent(),
-            new HashMap<>(),
-            false,
-            Optional.absent());
-      } else {
-        LOG.warn("No service present for {} to process endpoints delete", serviceId);
-      }
-    } else if (maybeService.isPresent()) {
-      LOG.info("Received service delete, but upstreams in other groups remain, removing upstreams for group {} from {}", upstreamGroup, serviceId);
-      BaragonRequest request = new BaragonRequest(
-          String.format("k8s-delete-%d", System.nanoTime()),
-          maybeService.get(),
+      // K8s integration supports a subset of features, take existing extra options if non-k8s upstreams also present
+      BaragonService relevantService = partitionedUpstreams.get(true).isEmpty() ?
+          updatedService :
+          stateDatastore.getService(updatedService.getServiceId()).or(updatedService);
+      BaragonRequest baragonRequest = new BaragonRequest(
+          String.format("k8s-update-service-%d", System.nanoTime()),
+          relevantService,
           Collections.emptyList(),
-          partitionedUpstreams.get(true),
+          Collections.emptyList(),
           Collections.emptyList(),
           Optional.absent(),
           Optional.of(RequestAction.UPDATE),
@@ -198,18 +81,143 @@ public class BaragonAgentKubernetesListener extends KubernetesListener {
       );
 
       Map<String, Collection<UpstreamInfo>> upstreamsForUpdate = new HashMap<>();
-      upstreamsForUpdate.put(serviceId, partitionedUpstreams.get(false));
+      upstreamsForUpdate.put(updatedService.getServiceId(), existingUpstreams);
 
       agentRequestManager.processRequest(
-          request.getLoadBalancerRequestId(),
+          baragonRequest.getLoadBalancerRequestId(),
           RequestAction.UPDATE,
-          request,
+          baragonRequest,
           Optional.absent(),
           upstreamsForUpdate,
           false,
           Optional.absent());
-    } else {
-      LOG.warn("No service present for {} to process endpoints delete", serviceId);
-    }
+    }, updatedService.getServiceId(), "processServiceUpdate");
+  }
+
+  @Override
+  public void processUpstreamsUpdate(String serviceId, String upstreamGroup, List<UpstreamInfo> activeUpstreams) {
+    serviceLock.runWithServiceLock(() -> {
+      Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+      if (!maybeService.isPresent()) {
+        LOG.info("No service definition for {}, skipping update", serviceId);
+        LOG.trace("Skipped update {} - {}", serviceId, activeUpstreams);
+        return;
+      }
+      if (!isRelevantUpdate(maybeService.get())) {
+        LOG.debug("Not relevant update for agent's group/domains, skipping ({})", serviceId);
+        LOG.trace("Skipped update {} - {}", serviceId, activeUpstreams);
+        return;
+      }
+
+      Collection<UpstreamInfo> existingUpstreams = stateDatastore.getUpstreams(serviceId);
+
+      List<UpstreamInfo> toRemove = existingUpstreams
+          .stream()
+          .filter((u) -> {
+            boolean groupMatches = u.getGroup().equals(upstreamGroup);
+            if (!groupMatches) {
+              return false;
+            }
+            for (UpstreamInfo active : activeUpstreams) {
+              if (UpstreamInfo.upstreamAndGroupMatches(u, active)) {
+                return false;
+              }
+            }
+            return true;
+          })
+          .collect(Collectors.toList());
+
+      BaragonRequest baragonRequest = new BaragonRequest(
+          String.format("k8s-update-uptreams-%d", System.nanoTime()),
+          maybeService.get(),
+          activeUpstreams,
+          toRemove,
+          Collections.emptyList(),
+          Optional.absent(),
+          Optional.of(RequestAction.UPDATE),
+          false,
+          false,
+          true,
+          false
+      );
+
+      Map<String, Collection<UpstreamInfo>> upstreamsForUpdate = new HashMap<>();
+      upstreamsForUpdate.put(serviceId, existingUpstreams);
+
+      agentRequestManager.processRequest(
+          baragonRequest.getLoadBalancerRequestId(),
+          RequestAction.UPDATE,
+          baragonRequest,
+          Optional.absent(),
+          upstreamsForUpdate,
+          false,
+          Optional.absent());
+    }, serviceId, "processUpstreamsUpdate");
+  }
+
+  @Override
+  public void processEndpointsDelete(String serviceId, String upstreamGroup) {
+    processDelete(serviceId, upstreamGroup);
+  }
+
+  private boolean isRelevantUpdate(BaragonService updatedService) {
+    boolean isUpdateForGroup = updatedService.getLoadBalancerGroups().contains(agentConfiguration.getLoadBalancerConfiguration().getName());
+    boolean isUpdateForDomain = !Sets.intersection(updatedService.getDomains(), agentConfiguration.getLoadBalancerConfiguration().getDomains()).isEmpty();
+    boolean isUpdateForDefaultDomain = updatedService.getDomains().contains(agentConfiguration.getLoadBalancerConfiguration().getDefaultDomain().or(""));
+    return isUpdateForGroup && (isUpdateForDomain || isUpdateForDefaultDomain);
+  }
+
+  private void processDelete(String serviceId, String upstreamGroup) {
+    serviceLock.runWithServiceLock(() -> {
+      Map<Boolean, List<UpstreamInfo>> partitionedUpstreams = stateDatastore.getUpstreams(serviceId)
+          .stream()
+          .collect(Collectors.partitioningBy((u) -> u.getGroup().equals(upstreamGroup)));
+      Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
+      if (partitionedUpstreams.get(false).isEmpty()) {
+        LOG.info("No remaining upstreams for {}, deleting", serviceId);
+        if (maybeService.isPresent()) {
+          BaragonRequest baragonRequest = createDeleteRequest(maybeService.get());
+          agentRequestManager.processRequest(
+              baragonRequest.getLoadBalancerRequestId(),
+              RequestAction.DELETE,
+              baragonRequest,
+              Optional.absent(),
+              new HashMap<>(),
+              false,
+              Optional.absent());
+        } else {
+          LOG.warn("No service present for {} to process endpoints delete", serviceId);
+        }
+      } else if (maybeService.isPresent()) {
+        LOG.info("Received service delete, but upstreams in other groups remain, removing upstreams for group {} from {}", upstreamGroup, serviceId);
+        BaragonRequest request = new BaragonRequest(
+            String.format("k8s-delete-%d", System.nanoTime()),
+            maybeService.get(),
+            Collections.emptyList(),
+            partitionedUpstreams.get(true),
+            Collections.emptyList(),
+            Optional.absent(),
+            Optional.of(RequestAction.UPDATE),
+            false,
+            false,
+            false,
+            false
+        );
+
+        Map<String, Collection<UpstreamInfo>> upstreamsForUpdate = new HashMap<>();
+        upstreamsForUpdate.put(serviceId, partitionedUpstreams.get(false));
+
+        agentRequestManager.processRequest(
+            request.getLoadBalancerRequestId(),
+            RequestAction.UPDATE,
+            request,
+            Optional.absent(),
+            upstreamsForUpdate,
+            false,
+            Optional.absent());
+      } else {
+        LOG.warn("No service present for {} to process endpoints delete", serviceId);
+      }
+    }, serviceId, "processDelete");
   }
 }


### PR DESCRIPTION
With the addition of the k8s integration, we likely need to lock on serviceId when making updates. In particular, we need to make sure that the state which the agent is fetching isn't out of date as compared to the state it is writing. Service has locks on writing state, so this is only relevant for agents. We could have a situation like the following:
- k8s update adds upstream A
- regular update adds upstream B
- k8s update hasn't reached BaragonService + zk when the regular update for B comes in
- update for B doesn't see A as an active upstream and only writes B to the file
- we don't receive any additional updates for A, so it's now missing

I see two possible ways of accomplishing this:
- lock on serviceId in the agent. This accounts for no two things pulling from the stateDatastore at different times, and is the implementation here. But, could fail in a race condition where we process a k8s update directly following a regular one (ie. we read the state from zk before the regular one that just succeeded has been committed by baragon service)
- Possibly use the new agent state cache (and maybe still lock on serviceId?) to make sure we are using the most recent upstreams. When updating from k8s we'll want to read all non-k8s upstreams from the state cache and the inverse when updating from the regular endpoint flow

This PR is mostly an attempt to figure out what a valid update mechanism is. It doesn't actually work yet