### PR TITLE
Fix alias handling with default domains

### DIFF
--- a/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonAliasDatastore.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/data/BaragonAliasDatastore.java
@@ -1,8 +1,6 @@
 package com.hubspot.baragon.data;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
@@ -12,14 +10,15 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.config.ZooKeeperConfiguration;
 import com.hubspot.baragon.models.BaragonGroupAlias;
-import com.hubspot.baragon.models.BaragonRequest;
 
 public class BaragonAliasDatastore extends AbstractDataStore {
 
   public static final String ALIASES_ROOT = "/aliases";
 
   @Inject
-  public BaragonAliasDatastore(CuratorFramework curatorFramework, ObjectMapper objectMapper, ZooKeeperConfiguration zooKeeperConfiguration) {
+  public BaragonAliasDatastore(CuratorFramework curatorFramework,
+                               ObjectMapper objectMapper,
+                               ZooKeeperConfiguration zooKeeperConfiguration) {
     super(curatorFramework, objectMapper, zooKeeperConfiguration);
   }
 
@@ -41,36 +40,5 @@ public class BaragonAliasDatastore extends AbstractDataStore {
 
   public void deleteAlias(String name) {
     deleteNode(getAliasPath(name));
-  }
-
-  public BaragonRequest updateForAliases(BaragonRequest original) {
-    Set<String> edgeCacheDomains = new HashSet<>(original.getLoadBalancerService().getEdgeCacheDomains());
-    if (original.getLoadBalancerService().getEdgeCacheDNS().isPresent()) {
-      edgeCacheDomains.add(original.getLoadBalancerService().getEdgeCacheDNS().get());
-    }
-    return original.withUpdatedGroups(
-        processAliases(
-            original.getLoadBalancerService().getLoadBalancerGroups(),
-            original.getLoadBalancerService().getDomains(),
-            edgeCacheDomains
-        )
-    );
-  }
-
-  public BaragonGroupAlias processAliases(Set<String> groups, Set<String> domains, Set<String> edgeCacheDomains) {
-    Set<String> allGroups = new HashSet<>();
-    Set<String> allDomains = new HashSet<>(domains);
-    Set<String> allEdgeCacheDomains = new HashSet<>(edgeCacheDomains);
-    for (String group : groups) {
-      Optional<BaragonGroupAlias> maybeAlias = getAlias(group);
-      if (maybeAlias.isPresent()) {
-        allGroups.addAll(maybeAlias.get().getGroups());
-        allDomains.addAll(maybeAlias.get().getDomains());
-        allEdgeCacheDomains.addAll(maybeAlias.get().getEdgeCacheDomains());
-      } else {
-        allGroups.add(group);
-      }
-    }
-    return new BaragonGroupAlias(allGroups, allDomains, allEdgeCacheDomains);
   }
 }

--- a/BaragonData/src/main/java/com/hubspot/baragon/managers/AliasManager.java
+++ b/BaragonData/src/main/java/com/hubspot/baragon/managers/AliasManager.java
@@ -1,0 +1,65 @@
+package com.hubspot.baragon.managers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.baragon.data.BaragonAliasDatastore;
+import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
+import com.hubspot.baragon.models.BaragonGroup;
+import com.hubspot.baragon.models.BaragonGroupAlias;
+import com.hubspot.baragon.models.BaragonRequest;
+
+public class AliasManager {
+  private static final Logger LOG = LoggerFactory.getLogger(AliasManager.class);
+
+  private final BaragonLoadBalancerDatastore loadBalancerDatastore;
+  private final BaragonAliasDatastore aliasDatastore;
+  @Inject
+  public AliasManager(BaragonLoadBalancerDatastore loadBalancerDatastore,
+                      BaragonAliasDatastore aliasDatastore) {
+    this.loadBalancerDatastore = loadBalancerDatastore;
+    this.aliasDatastore = aliasDatastore;
+  }
+
+  public BaragonRequest updateForAliases(BaragonRequest original) {
+    Set<String> edgeCacheDomains = new HashSet<>(original.getLoadBalancerService().getEdgeCacheDomains());
+    if (original.getLoadBalancerService().getEdgeCacheDNS().isPresent()) {
+      edgeCacheDomains.add(original.getLoadBalancerService().getEdgeCacheDNS().get());
+    }
+    return original.withUpdatedGroups(
+        processAliases(
+            original.getLoadBalancerService().getLoadBalancerGroups(),
+            original.getLoadBalancerService().getDomains(),
+            edgeCacheDomains
+        )
+    );
+  }
+
+  public BaragonGroupAlias processAliases(Set<String> groups, Set<String> domains, Set<String> edgeCacheDomains) {
+    Set<String> allGroups = new HashSet<>();
+    Set<String> allDomains = new HashSet<>(domains);
+    Set<String> allEdgeCacheDomains = new HashSet<>(edgeCacheDomains);
+    for (String group : groups) {
+      Optional<BaragonGroupAlias> maybeAlias = aliasDatastore.getAlias(group);
+      if (maybeAlias.isPresent()) {
+        allGroups.addAll(maybeAlias.get().getGroups());
+        allDomains.addAll(maybeAlias.get().getDomains());
+        allEdgeCacheDomains.addAll(maybeAlias.get().getEdgeCacheDomains());
+      } else {
+        Optional<BaragonGroup> maybeGroup = loadBalancerDatastore.getLoadBalancerGroup(group);
+        // If we don't add the default domain here, it can get missed in the normal default domains
+        // call, which excludes it based on the presence of any other domain for the group
+        if (maybeGroup.isPresent() && maybeGroup.get().getDefaultDomain().isPresent()) {
+          allDomains.add(maybeGroup.get().getDefaultDomain().get());
+        }
+        allGroups.add(group);
+      }
+    }
+    return new BaragonGroupAlias(allGroups, allDomains, allEdgeCacheDomains);
+  }
+}

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/resources/RequestResource.java
@@ -26,9 +26,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.hubspot.baragon.auth.NoAuth;
-import com.hubspot.baragon.data.BaragonAliasDatastore;
 import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.managers.AliasManager;
 import com.hubspot.baragon.models.BaragonRequest;
 import com.hubspot.baragon.models.BaragonRequestBuilder;
 import com.hubspot.baragon.models.BaragonResponse;
@@ -48,16 +48,16 @@ public class RequestResource {
   private final BaragonStateDatastore stateDatastore;
   private final BaragonLoadBalancerDatastore loadBalancerDatastore;
   private final RequestManager manager;
-  private final BaragonAliasDatastore aliasDatastore;
+  private final AliasManager aliasManager;
 
   @Inject
   public RequestResource(BaragonStateDatastore stateDatastore,
                          RequestManager manager,
-                         BaragonAliasDatastore aliasDatastore,
+                         AliasManager aliasManager,
                          BaragonLoadBalancerDatastore loadBalancerDatastore) {
     this.stateDatastore = stateDatastore;
     this.manager = manager;
-    this.aliasDatastore = aliasDatastore;
+    this.aliasManager = aliasManager;
     this.loadBalancerDatastore = loadBalancerDatastore;
   }
 
@@ -71,7 +71,7 @@ public class RequestResource {
   @POST
   public BaragonResponse enqueueRequest(@Valid BaragonRequest request) {
     try {
-      BaragonRequest updatedForAliases = aliasDatastore.updateForAliases(request);
+      BaragonRequest updatedForAliases = aliasManager.updateForAliases(request);
       BaragonRequest updatedForDefaultDomains = loadBalancerDatastore.updateForDefaultDomains(updatedForAliases);
       LOG.info("Received request: {}", request);
       return manager.enqueueRequest(updatedForDefaultDomains);


### PR DESCRIPTION
If specifying an alias for a group _and_ the group itself, this should still add the default domain for the group. Currently it doesn't. This adds the default domain in the alias update so that it isn't excluded in the subsequent check.