### PR TITLE
More complete check for in-progress service update by id

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -279,7 +279,7 @@ public class BaragonRequestWorker implements Runnable {
 
       // First process results for any requests that were already in-flight
       List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
-          .filter((q) -> q.getCurrentState().isInFlight())
+          .filter((q) -> q.getCurrentState().isInFlight() || hasInProgressAttempt(q))
           .collect(Collectors.toList());
       LOG.debug("Processing {} BaragonRequests which are already in-flight", inFlightRequests.size());
       handleResultStates(handleQueuedRequests(inFlightRequests));

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/worker/BaragonRequestWorker.java
@@ -264,23 +264,24 @@ public class BaragonRequestWorker implements Runnable {
           .filter(Optional::isPresent)
           .map(Optional::get)
           .collect(Collectors.toList());
-      final Set<String> inProgressServices = queuedRequests.stream()
+
+      List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
           .filter((q) -> q.getCurrentState().isInFlight() || hasInProgressAttempt(q))
+          .collect(Collectors.toList());
+
+      final Set<String> inProgressServices = inFlightRequests.stream()
           .map((q) -> q.getQueuedRequestId().getServiceId())
           .collect(Collectors.toSet());
 
       final Set<QueuedRequestWithState> removedForCurrentInFlightRequest = queuedRequests.stream()
-          .filter((q) -> inProgressServices.contains(q.getQueuedRequestId().getServiceId()) && !q.getCurrentState().isInFlight())
+          .filter((q) -> inProgressServices.contains(q.getQueuedRequestId().getServiceId()) && !inFlightRequests.contains(q))
           .collect(Collectors.toSet());
-      if (!inProgressServices.isEmpty()) {
+      if (!inFlightRequests.isEmpty()) {
         LOG.info("Skipping new updates for services {} due to current in-flight updates", String.join(",", inProgressServices));
       }
       queuedRequests.removeAll(removedForCurrentInFlightRequest);
 
       // First process results for any requests that were already in-flight
-      List<QueuedRequestWithState> inFlightRequests = queuedRequests.stream()
-          .filter((q) -> q.getCurrentState().isInFlight() || hasInProgressAttempt(q))
-          .collect(Collectors.toList());
       LOG.debug("Processing {} BaragonRequests which are already in-flight", inFlightRequests.size());
       handleResultStates(handleQueuedRequests(inFlightRequests));
       queuedRequests.removeAll(inFlightRequests);


### PR DESCRIPTION
This is a follow up from #325 . There is a case we missed when limiting a service from having two concurrent updates. When a retry to an agent has to be triggered, the request state is set back to SEND_APPLY_REQUESTS in order to trigger those. However, that state is not considered 'in-flight' by itself, which could accidentally allow the initial attempt of another update for the same service to be triggered.

This adds a more thorough check for requests in send apply state to also check if they have any outstanding agent responses.