### PR TITLE
Add auto-fix of out of sync issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 
-install: false
 script: mvn -B -q -DskipBaragonWebUI verify
 cache:
   directories:

--- a/BaragonAgentService/pom.xml
+++ b/BaragonAgentService/pom.xml
@@ -80,8 +80,8 @@
       <artifactId>dropwizard-guicier</artifactId>
     </dependency>
     <dependency>
-      <groupId>de.danielbechler</groupId>
-      <artifactId>java-object-diff</artifactId>
+      <groupId>com.flipkart.zjsonpatch</groupId>
+      <artifactId>zjsonpatch</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
@@ -1,6 +1,7 @@
 package com.hubspot.baragon.agent.healthcheck;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +69,7 @@ public class InternalStateChecker implements Runnable {
   public void run() {
     Set<String> invalidServiceMessages = new HashSet<>();
     long now = System.currentTimeMillis();
-    internalStateCache.forEach((serviceId, context) -> {
+    new HashMap<>(internalStateCache).forEach((serviceId, context) -> {
       Optional<BaragonService> maybeService = stateDatastore.getService(serviceId);
       if (!maybeService.isPresent()) {
         invalidServiceMessages.add(String.format("%s no longer exists in state datastore, but exists in agent", serviceId));
@@ -104,6 +105,8 @@ public class InternalStateChecker implements Runnable {
               }
               try {
                 configHelper.bootstrapApply(maybeCheck.get().getKey(), maybeCheck.get().getValue());
+                BasicServiceContext newContext = new BasicServiceContext(maybeCheck.get().getKey().getService(), maybeCheck.get().getKey().getUpstreams());
+                internalStateCache.put(serviceId, newContext);
               } finally {
                 agentLock.unlock();
               }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/healthcheck/InternalStateChecker.java
@@ -5,39 +5,61 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.zjsonpatch.JsonDiff;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.hubspot.baragon.agent.BaragonAgentServiceModule;
 import com.hubspot.baragon.agent.config.LoadBalancerConfiguration;
+import com.hubspot.baragon.agent.lbs.BootstrapFileChecker;
+import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
+import com.hubspot.baragon.data.BaragonRequestDatastore;
 import com.hubspot.baragon.data.BaragonStateDatastore;
+import com.hubspot.baragon.exceptions.LockTimeoutException;
+import com.hubspot.baragon.models.BaragonConfigFile;
 import com.hubspot.baragon.models.BaragonService;
+import com.hubspot.baragon.models.BaragonServiceState;
 import com.hubspot.baragon.models.BasicServiceContext;
+import com.hubspot.baragon.models.ServiceContext;
 import com.hubspot.baragon.models.UpstreamInfo;
-
-import de.danielbechler.diff.ObjectDifferBuilder;
 
 @Singleton
 public class InternalStateChecker implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(InternalStateChecker.class);
 
   private final BaragonStateDatastore stateDatastore;
+  private final BaragonRequestDatastore requestDatastore;
   private final LoadBalancerConfiguration loadBalancerConfiguration;
+  private final FilesystemConfigHelper configHelper;
   private final Map<String, BasicServiceContext> internalStateCache;
   private final Set<String> stateErrors;
+  private final ObjectMapper objectMapper;
+  private final ReentrantLock agentLock;
 
   @Inject
   public InternalStateChecker(BaragonStateDatastore stateDatastore,
+                              BaragonRequestDatastore requestDatastore,
                               LoadBalancerConfiguration loadBalancerConfiguration,
+                              ObjectMapper objectMapper,
+                              FilesystemConfigHelper configHelper,
+                              @Named(BaragonAgentServiceModule.AGENT_LOCK) ReentrantLock agentLock,
                               @Named(BaragonAgentServiceModule.INTERNAL_STATE_CACHE) Map<String, BasicServiceContext> internalStateCache,
                               @Named(BaragonAgentServiceModule.LOCAL_STATE_ERROR_MESSAGE) Set<String> stateErrors) {
     this.stateDatastore = stateDatastore;
+    this.requestDatastore = requestDatastore;
     this.loadBalancerConfiguration = loadBalancerConfiguration;
+    this.configHelper = configHelper;
+    this.objectMapper = objectMapper;
+    this.agentLock = agentLock;
     this.internalStateCache = internalStateCache;
     this.stateErrors = stateErrors;
   }
@@ -60,6 +82,36 @@ public class InternalStateChecker implements Runnable {
       BasicServiceContext datastoreContext = new BasicServiceContext(maybeService.get(), existingUpstreams);
       if (!datastoreContext.equals(context) && now - context.getTimestamp() > TimeUnit.SECONDS.toMillis(60)) {
         invalidServiceMessages.add(getDiffMessage(context, datastoreContext));
+        if (requestDatastore.getQueuedRequestIds()
+            .stream()
+            .noneMatch((q) -> q.getServiceId().equals(serviceId))) {
+          Optional<BaragonService> maybeUpdatedService = stateDatastore.getService(serviceId);
+          if (!maybeUpdatedService.isPresent()) {
+            LOG.warn("Service data no longer present, skipping auto-fix for {}", serviceId);
+            return;
+          }
+          Optional<Pair<ServiceContext, Collection<BaragonConfigFile>>> maybeCheck = new BootstrapFileChecker(
+              configHelper,
+              new BaragonServiceState(maybeUpdatedService.get(), stateDatastore.getUpstreams(serviceId)),
+              now
+          ).call();
+          if (maybeCheck.isPresent()) {
+            try {
+              if (!agentLock.tryLock(10, TimeUnit.MILLISECONDS)) {
+                LockTimeoutException lte = new LockTimeoutException("Timed out waiting to acquire lock", agentLock);
+                LOG.warn("Failed to acquire lock for service config apply ({})", serviceId, lte);
+                throw lte;
+              }
+              try {
+                configHelper.bootstrapApply(maybeCheck.get().getKey(), maybeCheck.get().getValue());
+              } finally {
+                agentLock.unlock();
+              }
+            } catch (Exception e) {
+              LOG.error("Failed to auto-fix configs for {}", serviceId, e);
+            }
+          }
+        }
       }
     });
     stateErrors.clear();
@@ -70,7 +122,10 @@ public class InternalStateChecker implements Runnable {
 
   private String getDiffMessage(BasicServiceContext agentContext, BasicServiceContext datastoreContext) {
     try {
-      return String.format("%s does not match state: %s", agentContext.getService().getServiceId(), ObjectDifferBuilder.buildDefault().compare(agentContext, datastoreContext).toString());
+      JsonNode agent = objectMapper.valueToTree(agentContext);
+      JsonNode datastore = objectMapper.valueToTree(datastoreContext);
+      JsonNode diff = JsonDiff.asJson(agent, datastore);
+      return String.format("%s does not match state: %s", agentContext.getService().getServiceId(), diff.toString());
     } catch (Throwable t) {
       LOG.warn("Could not generate baragon service diff message", t);
       return String.format("Agent context for %s does not match baragon state (Agent: %s, Service: %s)", agentContext.getService().getServiceId(), agentContext, datastoreContext);

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
       <dependency>
         <groupId>com.flipkart.zjsonpatch</groupId>
         <artifactId>zjsonpatch</artifactId>
-        <version>0.4.10</version>
+        <version>0.4.9</version>
       </dependency>
 
       <!-- metrics -->

--- a/pom.xml
+++ b/pom.xml
@@ -230,9 +230,9 @@
       </dependency>
 
       <dependency>
-        <groupId>de.danielbechler</groupId>
-        <artifactId>java-object-diff</artifactId>
-        <version>0.95</version>
+        <groupId>com.flipkart.zjsonpatch</groupId>
+        <artifactId>zjsonpatch</artifactId>
+        <version>0.4.10</version>
       </dependency>
 
       <!-- metrics -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <baragon.jar.name.format>${project.artifactId}-${project.version}</baragon.jar.name.format>
     <basepom.jar.name.format>${baragon.jar.name.format}</basepom.jar.name.format>
     <dep.classmate.version>1.3.1</dep.classmate.version>
+    <dep.commons-collections4.version>4.2</dep.commons-collections4.version>
     <dep.commons-lang3.version>3.9</dep.commons-lang3.version>
     <dep.curator.version>4.2.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.5</dep.dropwizard-metrics.version>


### PR DESCRIPTION
@pschoenfelder mind giving this one a once over?

Adds a way for the agent to automatically reconcile when it is out of sync with baragon service under the following conditions:
- no updates to the service in > 60s
- service still exists in zk state
- no pending updates for the service

If those conditions are met, it calls a shortened version of the bootstrap apply code to fix the issue and update the internal state cache. This particular state can be triggered when a lock timeout or pile up of requests to the agent occurs during apply, followed by a revert on the same agent also failing