### PR TITLE
Add a file watcher for directories that need to be reloaded

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -50,6 +50,7 @@ import com.hubspot.baragon.agent.healthcheck.ZooKeeperHealthcheck;
 import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
 import com.hubspot.baragon.agent.lbs.LbConfigGenerator;
 import com.hubspot.baragon.agent.lbs.LocalLbAdapter;
+import com.hubspot.baragon.agent.listeners.DirectoryChangesListener;
 import com.hubspot.baragon.agent.listeners.ResyncListener;
 import com.hubspot.baragon.agent.managed.BaragonAgentGraphiteReporterManaged;
 import com.hubspot.baragon.agent.managed.BootstrapManaged;
@@ -122,6 +123,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
     binder.bind(FilesystemConfigHelper.class).in(Scopes.SINGLETON);
     binder.bind(AgentHeartbeatWorker.class).in(Scopes.SINGLETON);
     binder.bind(InternalStateChecker.class).in(Scopes.SINGLETON);
+    binder.bind(DirectoryChangesListener.class).in(Scopes.SINGLETON);
 
     final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/BaragonAgentConfiguration.java
@@ -1,5 +1,6 @@
 package com.hubspot.baragon.agent.config;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -141,6 +142,9 @@ public class BaragonAgentConfiguration extends Configuration {
 
   @JsonProperty
   private boolean enablePollingStateValidation = false;
+
+  @JsonProperty("watchedDirectories")
+  private List<WatchedDirectoryConfig> watchedDirectories = new ArrayList<>();
 
   public HttpClientConfiguration getHttpClientConfiguration() {
     return httpClientConfiguration;
@@ -416,5 +420,13 @@ public class BaragonAgentConfiguration extends Configuration {
 
   public void setEnablePollingStateValidation(boolean enablePollingStateValidation) {
     this.enablePollingStateValidation = enablePollingStateValidation;
+  }
+
+  public List<WatchedDirectoryConfig> getWatchedDirectories() {
+    return watchedDirectories;
+  }
+
+  public void setWatchedDirectories(List<WatchedDirectoryConfig> watchedDirectories) {
+    this.watchedDirectories = watchedDirectories;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/WatchedDirectoryConfig.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/WatchedDirectoryConfig.java
@@ -2,15 +2,13 @@ package com.hubspot.baragon.agent.config;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import com.google.common.base.Optional;
+import java.util.Objects;
 
 public class WatchedDirectoryConfig {
   private String source;
   private Path sourcePath = null;
   private String destination;
   private Path destinationPath;
-  private Optional<String> matcher;
 
   public String getSource() {
     return source;
@@ -38,11 +36,29 @@ public class WatchedDirectoryConfig {
     this.destinationPath = Paths.get(destination);
   }
 
-  public Optional<String> getMatcher() {
-    return matcher;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WatchedDirectoryConfig that = (WatchedDirectoryConfig) o;
+    return Objects.equals(source, that.source) &&
+        Objects.equals(destination, that.destination);
   }
 
-  public void setMatcher(Optional<String> matcher) {
-    this.matcher = matcher;
+  @Override
+  public int hashCode() {
+    return Objects.hash(source, destination);
+  }
+
+  @Override
+  public String toString() {
+    return "WatchedDirectoryConfig{" +
+        "source='" + source + '\'' +
+        ", destination='" + destination + '\'' +
+        '}';
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/WatchedDirectoryConfig.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/WatchedDirectoryConfig.java
@@ -1,0 +1,48 @@
+package com.hubspot.baragon.agent.config;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.google.common.base.Optional;
+
+public class WatchedDirectoryConfig {
+  private String source;
+  private Path sourcePath = null;
+  private String destination;
+  private Path destinationPath;
+  private Optional<String> matcher;
+
+  public String getSource() {
+    return source;
+  }
+
+  public Path getSourceAsPath() {
+    return sourcePath;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+    this.sourcePath = Paths.get(source);
+  }
+
+  public String getDestination() {
+    return destination;
+  }
+
+  public Path getDestinationAsPath() {
+    return destinationPath;
+  }
+
+  public void setDestination(String destination) {
+    this.destination = destination;
+    this.destinationPath = Paths.get(destination);
+  }
+
+  public Optional<String> getMatcher() {
+    return matcher;
+  }
+
+  public void setMatcher(Optional<String> matcher) {
+    this.matcher = matcher;
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -1,0 +1,170 @@
+package com.hubspot.baragon.agent.listeners;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.hubspot.baragon.agent.BaragonAgentServiceModule;
+import com.hubspot.baragon.agent.config.BaragonAgentConfiguration;
+import com.hubspot.baragon.agent.config.WatchedDirectoryConfig;
+import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
+import com.hubspot.baragon.exceptions.LockTimeoutException;
+
+@Singleton
+public class DirectoryChangesListener {
+  private static final Logger LOG = LoggerFactory.getLogger(DirectoryChangesListener.class);
+
+  private final BaragonAgentConfiguration configuration;
+  private final FilesystemConfigHelper filesystemConfigHelper;
+  private final ReentrantLock agentLock;
+  private final ExecutorService executorService;
+  private final AtomicReference<String> fileCopyErrorMessage;
+
+  private Future<?> future;
+
+  @Inject
+  public DirectoryChangesListener(BaragonAgentConfiguration configuration,
+                                  FilesystemConfigHelper filesystemConfigHelper,
+                                  @Named(BaragonAgentServiceModule.AGENT_LOCK) ReentrantLock agentLock) {
+    this.configuration = configuration;
+    this.filesystemConfigHelper = filesystemConfigHelper;
+    this.agentLock = agentLock;
+    this.fileCopyErrorMessage = new AtomicReference<>(null);
+    this.executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("directory-watcher-%d").build());
+  }
+
+  public void start() throws Exception {
+    if (!configuration.getWatchedDirectories().isEmpty()) {
+      for (WatchedDirectoryConfig config : configuration.getWatchedDirectories()) {
+        // initial setup
+        handleFileChangeForDirectory(config);
+      }
+      future = executorService.submit(() -> this.watchDirectories(configuration.getWatchedDirectories()));
+    }
+  }
+
+  public void stop() {
+    if (future != null) {
+      future.cancel(true);
+    }
+    executorService.shutdown();
+  }
+
+  private void watchDirectories(List<WatchedDirectoryConfig> directoryConfigs) {
+    while (!Thread.interrupted()) {
+      try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
+        Map<WatchKey, WatchedDirectoryConfig> watchKeyToDirectory = new HashMap<>();
+        for (WatchedDirectoryConfig d : directoryConfigs) {
+          LOG.info("Watching directory {} to copy to {}", d.getSource(), d.getDestination());
+          Path path = d.getSourceAsPath();
+          watchKeyToDirectory.put(path.register(watchService), d);
+        }
+        while (!Thread.interrupted()) {
+          WatchKey key = watchService.take();
+          for (WatchEvent<?> event : key.pollEvents()) {
+            if (event.kind().equals(StandardWatchEventKinds.OVERFLOW)) {
+              LOG.warn("Overflow event received, stopping file watch");
+              return;
+            }
+            WatchedDirectoryConfig config = watchKeyToDirectory.get(key);
+            handleFileChangeForDirectory(config);
+          }
+          boolean valid = key.reset();
+          if (!valid) {
+            LOG.warn("Key for {} is not accessible, stopping watch", watchKeyToDirectory.get(key));
+          }
+        }
+      } catch (InterruptedException ie) {
+        LOG.warn("Interrupted, shutting down");
+        return;
+      } catch (Exception e) {
+        fileCopyErrorMessage.set(e.getMessage());
+        LOG.error("Unexpected exception while watching directories", e);
+      }
+      try {
+        LOG.warn("Watcher unexpectedly exited, sleeping and restarting");
+        Thread.sleep(30000);
+      } catch (InterruptedException ie) {
+        LOG.warn("Interrupted, shutting down");
+        return;
+      }
+    }
+  }
+
+  public void handleFileChangeForDirectory(WatchedDirectoryConfig config) throws Exception {
+    if (!agentLock.tryLock(45, TimeUnit.SECONDS)) {
+      LOG.warn("Failed to acquire lock for reload");
+      throw new LockTimeoutException("Timed out waiting to acquire lock for reload", agentLock);
+    }
+    try {
+      List<Path> destinationFiles = getFilesInDirectory(config.getDestinationAsPath());
+      for (Path path : destinationFiles) {
+        filesystemConfigHelper.backupFile(path.toAbsolutePath().toString());
+      }
+      LOG.info("Backed up {} files in {}", destinationFiles.size(), config.getDestination());
+      try {
+        LOG.info("Copying files from {} to {}", config.getSource(), config.getDestination());
+        List<Path> toCopy = getFilesInDirectory(config.getSourceAsPath());
+        for (Path from : toCopy) {
+          Path to = Paths.get(from.toAbsolutePath().toString().replace(config.getSource(), config.getDestination()));
+          Files.copy(from, to);
+        }
+        LOG.info("Copied {} files to {}", toCopy.size(), config.getDestination());
+        filesystemConfigHelper.checkAndReloadUnlocked();
+        LOG.info("File copy succeeded for {}", config);
+        fileCopyErrorMessage.set(null);
+      } catch (Exception e) {
+        fileCopyErrorMessage.set(e.getMessage());
+        List<Path> toCleanUp = getFilesInDirectory(config.getDestinationAsPath());
+        for (Path path : toCleanUp) {
+          Path absolute = path.toAbsolutePath();
+          if (filesystemConfigHelper.isBackupFile(absolute.toString())) {
+            Files.delete(absolute);
+          } else {
+            filesystemConfigHelper.restoreFile(absolute.toString());
+          }
+        }
+        LOG.info("Cleaned up {} files in {} due to exception", toCleanUp.size(), config.getDestination());
+        throw e;
+      }
+    } finally {
+      agentLock.unlock();
+    }
+  }
+
+  private List<Path> getFilesInDirectory(Path directory) throws IOException {
+    try (Stream<Path> walk = Files.walk(directory)) {
+      return walk.filter(Files::isRegularFile)
+          .collect(Collectors.toList());
+    }
+  }
+
+  public Optional<String> getErrorMessage() {
+    return Optional.fromNullable(fileCopyErrorMessage.get());
+  }
+}

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -39,6 +39,8 @@ import com.hubspot.baragon.agent.config.WatchedDirectoryConfig;
 import com.hubspot.baragon.agent.lbs.FilesystemConfigHelper;
 import com.hubspot.baragon.exceptions.LockTimeoutException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 @Singleton
 public class DirectoryChangesListener {
   private static final Logger LOG = LoggerFactory.getLogger(DirectoryChangesListener.class);
@@ -92,7 +94,7 @@ public class DirectoryChangesListener {
     pendingUpdates.remove(config);
   }
 
-  @SuppressWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
   private void watchDirectories(List<WatchedDirectoryConfig> directoryConfigs) {
     while (!Thread.interrupted()) {
       try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
@@ -190,7 +192,7 @@ public class DirectoryChangesListener {
     }
   }
 
-  @SuppressWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
   private List<Path> getFilesInDirectory(Path directory) throws IOException {
     try (Stream<Path> walk = Files.walk(directory)) {
       return walk.filter(Files::isRegularFile)

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -102,7 +102,7 @@ public class DirectoryChangesListener {
         for (WatchedDirectoryConfig d : directoryConfigs) {
           LOG.info("Watching directory {} to copy to {}", d.getSource(), d.getDestination());
           Path path = d.getSourceAsPath();
-          watchKeyToDirectory.put(path.register(watchService), d);
+          watchKeyToDirectory.put(path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY), d);
         }
         while (!Thread.interrupted()) {
           WatchKey key = watchService.take();

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -189,7 +189,7 @@ public class DirectoryChangesListener {
           }
           for (Path path : backedUpFiles) {
             LOG.info("Restoring file {}", path);
-            filesystemConfigHelper.restoreFile(path.getFileName().toString());
+            filesystemConfigHelper.restoreFile(path.toString());
           }
           LOG.info("Files in destination dir are now {}", getFilesInDirectory(config.getDestinationAsPath()));
           throw e;

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -156,9 +156,11 @@ public class DirectoryChangesListener {
       try {
         List<Path> destinationFiles = getFilesInDirectory(config.getDestinationAsPath());
         for (Path path : destinationFiles) {
+          LOG.info("Backing up {}", path);
           filesystemConfigHelper.backupFile(path.toAbsolutePath().toString());
         }
         LOG.info("Backed up {} files in {}", destinationFiles.size(), config.getDestination());
+        LOG.info("Files in destination dir are now {}", getFilesInDirectory(config.getDestinationAsPath()));
         try {
           LOG.info("Copying files from {} to {}", config.getSource(), config.getDestination());
           List<Path> toCopy = getFilesInDirectory(config.getSourceAsPath());
@@ -168,6 +170,7 @@ public class DirectoryChangesListener {
             Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
           }
           LOG.info("Copied {} files to {}", toCopy.size(), config.getDestination());
+          LOG.info("Files in destination dir are now {}", getFilesInDirectory(config.getDestinationAsPath()));
           filesystemConfigHelper.checkAndReloadUnlocked();
           LOG.info("File copy succeeded for {}", config);
           fileCopyErrorMessage.set(null);
@@ -183,6 +186,7 @@ public class DirectoryChangesListener {
             }
           }
           LOG.info("Cleaned up {} files in {} due to exception", toCleanUp.size(), config.getDestination());
+          LOG.info("Files in destination dir are now {}", getFilesInDirectory(config.getDestinationAsPath()));
           throw e;
         }
       } finally {

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -163,7 +163,8 @@ public class DirectoryChangesListener {
           LOG.info("Copying files from {} to {}", config.getSource(), config.getDestination());
           List<Path> toCopy = getFilesInDirectory(config.getSourceAsPath());
           for (Path from : toCopy) {
-            Path to = Paths.get(from.toAbsolutePath().toString().replace(config.getSource(), config.getDestination()));
+            Path to = config.getDestinationAsPath().resolve(from.getFileName().toString());
+            LOG.info("Copying {} to {}", from, to);
             Files.copy(from, to);
           }
           LOG.info("Copied {} files to {}", toCopy.size(), config.getDestination());

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -92,6 +92,7 @@ public class DirectoryChangesListener {
     pendingUpdates.remove(config);
   }
 
+  @SuppressWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
   private void watchDirectories(List<WatchedDirectoryConfig> directoryConfigs) {
     while (!Thread.interrupted()) {
       try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
@@ -189,6 +190,7 @@ public class DirectoryChangesListener {
     }
   }
 
+  @SuppressWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
   private List<Path> getFilesInDirectory(Path directory) throws IOException {
     try (Stream<Path> walk = Files.walk(directory)) {
       return walk.filter(Files::isRegularFile)

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/listeners/DirectoryChangesListener.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
@@ -165,7 +165,7 @@ public class DirectoryChangesListener {
           for (Path from : toCopy) {
             Path to = config.getDestinationAsPath().resolve(from.getFileName().toString());
             LOG.info("Copying {} to {}", from, to);
-            Files.copy(from, to);
+            Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
           }
           LOG.info("Copied {} files to {}", toCopy.size(), config.getDestination());
           filesystemConfigHelper.checkAndReloadUnlocked();

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/StatusResource.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/resources/StatusResource.java
@@ -23,6 +23,7 @@ import com.hubspot.baragon.BaragonDataModule;
 import com.hubspot.baragon.agent.BaragonAgentServiceModule;
 import com.hubspot.baragon.agent.config.LoadBalancerConfiguration;
 import com.hubspot.baragon.agent.lbs.LocalLbAdapter;
+import com.hubspot.baragon.agent.listeners.DirectoryChangesListener;
 import com.hubspot.baragon.auth.NoAuth;
 import com.hubspot.baragon.exceptions.InvalidConfigException;
 import com.hubspot.baragon.models.BaragonAgentMetadata;
@@ -43,12 +44,14 @@ public class StatusResource {
   private final Set<String> stateErrors;
   private final AtomicReference<BaragonAgentState> agentState;
   private final Map<String, BasicServiceContext> internalStateCache;
+  private final DirectoryChangesListener directoryChangesListener;
 
   @Inject
   public StatusResource(LocalLbAdapter adapter,
                         LoadBalancerConfiguration loadBalancerConfiguration,
                         BaragonAgentMetadata agentMetadata,
                         AtomicReference<BaragonAgentState> agentState,
+                        DirectoryChangesListener directoryChangesListener,
                         @Named(BaragonAgentServiceModule.AGENT_LEADER_LATCH) LeaderLatch leaderLatch,
                         @Named(BaragonAgentServiceModule.AGENT_MOST_RECENT_REQUEST_ID) AtomicReference<String> mostRecentRequestId,
                         @Named(BaragonDataModule.BARAGON_ZK_CONNECTION_STATE) AtomicReference<ConnectionState> connectionState,
@@ -65,6 +68,7 @@ public class StatusResource {
     this.stateErrors = stateErrors;
     this.agentState = agentState;
     this.internalStateCache = internalStateCache;
+    this.directoryChangesListener = directoryChangesListener;
   }
 
   @GET
@@ -94,7 +98,8 @@ public class StatusResource {
         connectionStateString,
         agentMetadata,
         agentState.get(),
-        currentStateErrors);
+        currentStateErrors,
+        directoryChangesListener.getErrorMessage());
   }
 
   @GET

--- a/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentStatus.java
+++ b/BaragonCore/src/main/java/com/hubspot/baragon/models/BaragonAgentStatus.java
@@ -19,6 +19,7 @@ public class BaragonAgentStatus {
   private final String zookeeperState;
   private final BaragonAgentMetadata agentInfo;
   private final BaragonAgentState agentState;
+  private final Optional<String> directoryWatcherError;
 
   @JsonCreator
   public BaragonAgentStatus(@JsonProperty("group") String group,
@@ -29,7 +30,8 @@ public class BaragonAgentStatus {
                             @JsonProperty("zookeeperState") String zookeeperState,
                             @JsonProperty("agentInfo") BaragonAgentMetadata agentInfo,
                             @JsonProperty("agentState") BaragonAgentState agentState,
-                            @JsonProperty("stateErrors") Set<String> stateErrors) {
+                            @JsonProperty("stateErrors") Set<String> stateErrors,
+                            @JsonProperty("directoryWatcherError") Optional<String> directoryWatcherError) {
     this.group = group;
     this.validConfigs = validConfigs;
     this.errorMessage = errorMessage;
@@ -39,6 +41,7 @@ public class BaragonAgentStatus {
     this.agentInfo = agentInfo;
     this.agentState = agentState;
     this.stateErrors = stateErrors;
+    this.directoryWatcherError = directoryWatcherError;
   }
 
   public String getGroup() {
@@ -77,6 +80,10 @@ public class BaragonAgentStatus {
     return stateErrors;
   }
 
+  public Optional<String> getDirectoryWatcherError() {
+    return directoryWatcherError;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +95,7 @@ public class BaragonAgentStatus {
     BaragonAgentStatus that = (BaragonAgentStatus) o;
     return validConfigs == that.validConfigs &&
         leader == that.leader &&
+        directoryWatcherError == that.directoryWatcherError &&
         Objects.equals(group, that.group) &&
         Objects.equals(errorMessage, that.errorMessage) &&
         Objects.equals(stateErrors, that.stateErrors) &&
@@ -99,7 +107,7 @@ public class BaragonAgentStatus {
 
   @Override
   public int hashCode() {
-    return Objects.hash(group, validConfigs, errorMessage, stateErrors, leader, mostRecentRequestId, zookeeperState, agentInfo, agentState);
+    return Objects.hash(group, validConfigs, errorMessage, stateErrors, leader, mostRecentRequestId, zookeeperState, agentInfo, agentState, directoryWatcherError);
   }
 
   @Override
@@ -114,6 +122,7 @@ public class BaragonAgentStatus {
         ", zookeeperState='" + zookeeperState + '\'' +
         ", agentInfo=" + agentInfo +
         ", agentState=" + agentState +
+        ", directoryWatcherError=" + directoryWatcherError +
         '}';
   }
 }


### PR DESCRIPTION
For some cases, like certificate updates, we may want to validate the new config before reloading. These certs may be laid down by puppet/chef/k8s secret updates/etc. This PR allows a configurable directory that will be watched for changes. When a change in the directory is detected, the whole directory will be copied over to a destination, validated, and either the config reloaded, or backups restored if the config ends up being invalid

 Still TODO:
- Right now when we see a change we copy everything over at once. Is there a better way to debounce this a bit? e.g. if a cert and key file are updated a second or two apart?