### PR TITLE
For dependency reduction for Baragon Workers

### DIFF
--- a/BaragonCore/pom.xml
+++ b/BaragonCore/pom.xml
@@ -10,6 +10,10 @@
 
   <artifactId>BaragonCore</artifactId>
 
+  <properties>
+    <allow.hubspot-standard-stack.dependencies>false</allow.hubspot-standard-stack.dependencies>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Baragon workers currently depend on BaragonCore. This PR is to tag the BaragonCore library with the new slim dependency stack. 