### PR TITLE
optional logrotate in baragon agent

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/BaragonAgentServiceModule.java
@@ -287,7 +287,7 @@ public class BaragonAgentServiceModule extends DropwizardAwareModule<BaragonAgen
   @Singleton
   @Named(AGENT_SCHEDULED_EXECUTOR)
   public ScheduledExecutorService providesScheduledExecutor() {
-    return Executors.newScheduledThreadPool(3);
+    return Executors.newScheduledThreadPool(4);
   }
 
   @Provides

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/LoadBalancerConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/LoadBalancerConfiguration.java
@@ -3,6 +3,7 @@ package com.hubspot.baragon.agent.config;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -29,6 +30,10 @@ public class LoadBalancerConfiguration {
 
   @NotNull
   private String reloadConfigCommand;
+
+  private Optional<String> logRotateCommand = Optional.absent();
+
+  private long rotateIntervalMillis = TimeUnit.HOURS.toMillis(1);
 
   @Min(0)
   private int commandTimeoutMs = DEFAULT_COMMAND_TIMEOUT_MS;
@@ -143,5 +148,21 @@ public class LoadBalancerConfiguration {
 
   public void setLimitWorkerCount(boolean limitWorkerCount) {
     this.limitWorkerCount = limitWorkerCount;
+  }
+
+  public Optional<String> getLogRotateCommand() {
+    return logRotateCommand;
+  }
+
+  public void setLogRotateCommand(Optional<String> logRotateCommand) {
+    this.logRotateCommand = logRotateCommand;
+  }
+
+  public long getRotateIntervalMillis() {
+    return rotateIntervalMillis;
+  }
+
+  public void setRotateIntervalMillis(long rotateIntervalMillis) {
+    this.rotateIntervalMillis = rotateIntervalMillis;
   }
 }


### PR DESCRIPTION
when running in containerized cases, it's useful for the agent to be able to run log rotation on an lb process, especially if one like nginx has to be sent a signal to reload its log files and therefore must be running in the same container. This PR adds an optional config parameter that will run a polling thread in the background