### PR TITLE
Add config to turn on and off static cache at a service level

### DIFF
--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/LoadBalancerConfiguration.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/config/LoadBalancerConfiguration.java
@@ -55,6 +55,9 @@ public class LoadBalancerConfiguration {
 
   private boolean turnOffPurgeableCacheInTemplates = false;
 
+  @NotNull
+  private Set<String> servicesToBlockFromPurgeableCache = Collections.emptySet();
+
   public String getName() {
     return name;
   }
@@ -174,5 +177,13 @@ public class LoadBalancerConfiguration {
 
   public void setTurnOffPurgeableCacheInTemplates(boolean turnOffPurgeableCacheInTemplates) {
     this.turnOffPurgeableCacheInTemplates = turnOffPurgeableCacheInTemplates;
+  }
+
+  public Set<String> getServicesToBlockFromPurgeableCache() {
+    return servicesToBlockFromPurgeableCache;
+  }
+
+  public void setServicesToBlockFromPurgeableCache(Set<String> servicesToBlockFromPurgeableCache) {
+    this.servicesToBlockFromPurgeableCache = servicesToBlockFromPurgeableCache;
   }
 }

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -25,9 +25,13 @@ import com.hubspot.baragon.models.BaragonConfigFile;
 import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.ServiceContext;
 import com.github.jknack.handlebars.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class LbConfigGenerator {
+  private static final Logger LOG = LoggerFactory.getLogger(LbConfigGenerator.class);
+
   private final LoadBalancerConfiguration loadBalancerConfiguration;
   private final Map<String, List<LbConfigTemplate>> templates;
   private final BaragonAgentMetadata agentMetadata;
@@ -54,6 +58,7 @@ public class LbConfigGenerator {
         final StringWriter sw = new StringWriter();
         final boolean turnOffPurgeableCacheInTemplates = loadBalancerConfiguration.isTurnOffPurgeableCacheInTemplates()
             || loadBalancerConfiguration.getServicesToBlockFromPurgeableCache().contains(snapshot.getService().getServiceId());
+        LOG.info("turnOffPurgeableCacheInTemplates={}, getServicesToBlockFromPurgeableCache()={}", turnOffPurgeableCacheInTemplates, loadBalancerConfiguration.getServicesToBlockFromPurgeableCache());
         final Context context = Context.newBuilder(snapshot)
             .combine("agentProperties", agentMetadata)
             .combine("serviceIdHash",

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -52,13 +52,15 @@ public class LbConfigGenerator {
         final List<String> filenames = getFilenames(template, snapshot.getService());
 
         final StringWriter sw = new StringWriter();
+        final boolean turnOffPurgeableCacheInTemplates = loadBalancerConfiguration.isTurnOffPurgeableCacheInTemplates()
+            || loadBalancerConfiguration.getServicesToBlockFromPurgeableCache().contains(snapshot.getService().getServiceId());
         final Context context = Context.newBuilder(snapshot)
             .combine("agentProperties", agentMetadata)
             .combine("serviceIdHash",
                 Hashing.sha256()
                 .hashString(snapshot.getService().getServiceId(), StandardCharsets.UTF_8)
                 .toString())
-            .combine("turnOffPurgeableCacheInTemplates", loadBalancerConfiguration.isTurnOffPurgeableCacheInTemplates())
+            .combine("turnOffPurgeableCacheInTemplates", turnOffPurgeableCacheInTemplates)
             .build();
         try {
           template.getTemplate().apply(context, sw);

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -25,8 +25,6 @@ import com.hubspot.baragon.models.BaragonConfigFile;
 import com.hubspot.baragon.models.BaragonService;
 import com.hubspot.baragon.models.ServiceContext;
 import com.github.jknack.handlebars.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class LbConfigGenerator {

--- a/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
+++ b/BaragonAgentService/src/main/java/com/hubspot/baragon/agent/lbs/LbConfigGenerator.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 @Singleton
 public class LbConfigGenerator {
-  private static final Logger LOG = LoggerFactory.getLogger(LbConfigGenerator.class);
 
   private final LoadBalancerConfiguration loadBalancerConfiguration;
   private final Map<String, List<LbConfigTemplate>> templates;
@@ -58,7 +57,6 @@ public class LbConfigGenerator {
         final StringWriter sw = new StringWriter();
         final boolean turnOffPurgeableCacheInTemplates = loadBalancerConfiguration.isTurnOffPurgeableCacheInTemplates()
             || loadBalancerConfiguration.getServicesToBlockFromPurgeableCache().contains(snapshot.getService().getServiceId());
-        LOG.info("turnOffPurgeableCacheInTemplates={}, getServicesToBlockFromPurgeableCache()={}", turnOffPurgeableCacheInTemplates, loadBalancerConfiguration.getServicesToBlockFromPurgeableCache());
         final Context context = Context.newBuilder(snapshot)
             .combine("agentProperties", agentMetadata)
             .combine("serviceIdHash",


### PR DESCRIPTION
Sometimes the purgeable cache should be turned off at a `serviceId` level.