### PR TITLE
Fix junit jupiter test set up

### DIFF
--- a/BaragonAgentService/pom.xml
+++ b/BaragonAgentService/pom.xml
@@ -174,16 +174,6 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/BaragonClient/pom.xml
+++ b/BaragonClient/pom.xml
@@ -72,16 +72,5 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/BaragonData/pom.xml
+++ b/BaragonData/pom.xml
@@ -144,18 +144,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/BaragonService/pom.xml
+++ b/BaragonService/pom.xml
@@ -237,16 +237,6 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/BaragonService/src/test/java/com/hubspot/baragon/service/worker/BaragonRequestWorkerTest.java
+++ b/BaragonService/src/test/java/com/hubspot/baragon/service/worker/BaragonRequestWorkerTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class BaragonRequestWorkerTest extends BaragonServiceTestBase {
@@ -29,6 +30,14 @@ public class BaragonRequestWorkerTest extends BaragonServiceTestBase {
 
   @Inject
   BaragonRequestWorker requestWorker;
+
+  @BeforeEach
+  public void beforeEach() {
+    // need to clean up requestManager so that the requests to don't persist
+    // between test runs
+    requestManager.deleteRequest("request1");
+    requestManager.deleteRequest("request2");
+  }
 
   @Test
   public void testQueuedRequestsAreBatchedForAgent() throws Exception {

--- a/BaragonServiceIntegrationTests/pom.xml
+++ b/BaragonServiceIntegrationTests/pom.xml
@@ -54,18 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
     <dep.jersey2.version>2.25.1</dep.jersey2.version>
     <dep.jetty.version>9.4.18.v20190429</dep.jetty.version>
     <dep.joda.version>2.10.1</dep.joda.version>
-    <dep.junit.jupiter.version>5.5.0</dep.junit.jupiter.version>
-    <dep.junit.platform.version>1.5.0</dep.junit.platform.version>
+    <dep.junit-jupiter.version>5.5.0</dep.junit-jupiter.version>
     <dep.logback.version>1.2.3</dep.logback.version>
     <dep.netty.version>4.1.27.Final</dep.netty.version>
     <dep.netty3.version>3.10.6.Final</dep.netty3.version>
@@ -59,6 +58,7 @@
     <horizon.version>0.1.2</horizon.version>
     <ning.async.version>1.9.38</ning.async.version>
     <ringleader.version>0.1.5</ringleader.version>
+    <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
   </properties>
 
   <dependencyManagement>
@@ -440,26 +440,12 @@
       </dependency>
 
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${dep.junit.jupiter.version}</version>
-        <scope>test</scope>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${dep.junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${dep.junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-runner</artifactId>
-        <version>${dep.junit.platform.version}</version>
-        <scope>test</scope>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Having `junit-platform-runner` on the classpath prevents maven from running junit 5 tests. As a result, none of the tests are currently being run. You confirm this by looking at Blazar build 487. With these changes, the tests are once again run via maven.

It seems as though `BaragonService` has broken tests that need to be fixed.

@ssalinas @jonathanwgoodwin @kmclarnon @Xcelled @snommit-mit