### PR TITLE
Auto-clean old known agents

### DIFF
--- a/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/BaragonServiceModule.java
@@ -45,6 +45,7 @@ import com.hubspot.baragon.service.exceptions.BaragonExceptionNotifier;
 import com.hubspot.baragon.service.gcloud.GoogleCloudManager;
 import com.hubspot.baragon.service.healthcheck.ZooKeeperHealthcheck;
 import com.hubspot.baragon.service.listeners.AbstractLatchListener;
+import com.hubspot.baragon.service.listeners.AgentCleanupListener;
 import com.hubspot.baragon.service.listeners.ElbSyncWorkerListener;
 import com.hubspot.baragon.service.listeners.RequestPurgingListener;
 import com.hubspot.baragon.service.listeners.RequestWorkerListener;
@@ -169,6 +170,7 @@ public class BaragonServiceModule extends DropwizardAwareModule<BaragonConfigura
     latchBinder.addBinding().to(RequestWorkerListener.class).in(Scopes.SINGLETON);
     latchBinder.addBinding().to(ElbSyncWorkerListener.class).in(Scopes.SINGLETON);
     latchBinder.addBinding().to(RequestPurgingListener.class).in(Scopes.SINGLETON);
+    latchBinder.addBinding().to(AgentCleanupListener.class).in(Scopes.SINGLETON);
   }
 
   @Provides
@@ -232,7 +234,7 @@ public class BaragonServiceModule extends DropwizardAwareModule<BaragonConfigura
   @Singleton
   @Named(BARAGON_SERVICE_SCHEDULED_EXECUTOR)
   public ScheduledExecutorService providesScheduledExecutor() {
-    return Executors.newScheduledThreadPool(4);
+    return Executors.newScheduledThreadPool(5);
   }
 
   @Provides

--- a/BaragonService/src/main/java/com/hubspot/baragon/service/listeners/AgentCleanupListener.java
+++ b/BaragonService/src/main/java/com/hubspot/baragon/service/listeners/AgentCleanupListener.java
@@ -1,0 +1,83 @@
+package com.hubspot.baragon.service.listeners;
+
+import com.google.inject.Inject;
+import com.hubspot.baragon.data.BaragonKnownAgentsDatastore;
+import com.hubspot.baragon.data.BaragonLoadBalancerDatastore;
+import com.hubspot.baragon.service.BaragonServiceModule;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AgentCleanupListener extends AbstractLatchListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ElbSyncWorkerListener.class);
+
+  private final ScheduledExecutorService executorService;
+  private final BaragonKnownAgentsDatastore knownAgentsDatastore;
+  private final BaragonLoadBalancerDatastore loadBalancerDatastore;
+
+  private ScheduledFuture<?> checkFuture = null;
+
+  @Inject
+  public AgentCleanupListener(
+    @Named(
+      BaragonServiceModule.BARAGON_SERVICE_SCHEDULED_EXECUTOR
+    ) ScheduledExecutorService executorService,
+    BaragonKnownAgentsDatastore knownAgentsDatastore,
+    BaragonLoadBalancerDatastore loadBalancerDatastore
+  ) {
+    this.executorService = executorService;
+    this.knownAgentsDatastore = knownAgentsDatastore;
+    this.loadBalancerDatastore = loadBalancerDatastore;
+  }
+
+  @Override
+  public void isLeader() {
+    LOG.info("We are the leader! Starting ElbSyncWorker...");
+
+    if (checkFuture != null) {
+      checkFuture.cancel(true);
+    }
+
+    checkFuture =
+      executorService.scheduleAtFixedRate(
+        this::cleanOldKnownAgents,
+        60,
+        60,
+        TimeUnit.SECONDS
+      );
+  }
+
+  @Override
+  public void notLeader() {
+    LOG.info("We are not the leader!");
+    checkFuture.cancel(true);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  private void cleanOldKnownAgents() {
+    try {
+      long now = System.currentTimeMillis();
+      long threshold = now - TimeUnit.MINUTES.toMillis(30);
+      for (String group : loadBalancerDatastore.getLoadBalancerGroupNames()) {
+        knownAgentsDatastore
+          .getKnownAgentsMetadata(group)
+          .forEach(
+            k -> {
+              if (k.getLastSeenAt() < threshold) {
+                knownAgentsDatastore.removeKnownAgent(group, k.getAgentId());
+              }
+            }
+          );
+      }
+    } catch (Exception e) {
+      LOG.error("Could not clean up old known agents", e);
+    }
+  }
+}


### PR DESCRIPTION
These can proliferate after deploying a number of times. Clean them up automatically